### PR TITLE
feat: add docker logs support and refactor scanner architecture

### DIFF
--- a/cmd/reqlog/main.go
+++ b/cmd/reqlog/main.go
@@ -9,6 +9,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/sagarmaheshwary/reqlog/internal/domain"
 	"github.com/sagarmaheshwary/reqlog/internal/formatter"
 	"github.com/sagarmaheshwary/reqlog/internal/parser"
 	"github.com/sagarmaheshwary/reqlog/internal/scanner"
@@ -24,6 +25,7 @@ var (
 	since       = flag.String("since", "", "only include logs newer than duration (e.g. 5m, 1h)")
 	recursive   = flag.Bool("recursive", true, "scan directories recursively")
 	service     = flag.String("service", "", "filter by service name (comma-separated, e.g. order-service,inventory-service)")
+	source      = flag.String("source", "file", `log source backend: "file", "docker"`)
 	showVersion = flag.Bool("version", false, "print version and exit")
 )
 
@@ -80,7 +82,7 @@ func main() {
 	flag.Parse()
 
 	if *showVersion {
-		fmt.Printf("reqlog version %s\n", Version())
+		fmt.Printf("reqlog version %s\n", cliVersion())
 		return
 	}
 
@@ -108,12 +110,12 @@ func main() {
 		parserType = parser.TypeJSON
 	}
 
-	p, err := parser.NewParser(parserType)
+	p, err := parser.New(parserType)
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	cfg := scanner.ScanConfig{
+	cfg := &scanner.ScanConfig{
 		Dir:         *dir,
 		SearchValue: SearchValue,
 		IgnoreCase:  *ignoreCase,
@@ -123,30 +125,28 @@ func main() {
 		Recursive:   *recursive,
 		Services:    services,
 	}
-	scn := scanner.NewFileScanner(cfg, p)
-
-	files, err := scn.ListLogFiles()
+	scn, err := scanner.New(*source, scanner.NewLineProcessor(cfg, p))
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	entries := scn.Scan(files)
-
-	sort.Slice(entries, func(i, j int) bool {
-		return entries[i].Timestamp.Before(entries[j].Timestamp)
-	})
-
-	f := formatter.NewFormatter(entries)
-	for _, e := range entries {
-		fmt.Println(f.Format(e))
+	sources, err := scn.ListSources()
+	if err != nil {
+		log.Fatal(err)
 	}
 
+	if len(sources) == 0 {
+		log.Fatal("no matching sources found")
+	}
+
+	printEntries(scn.Scan(sources))
+
 	if *follow {
-		scn.Follow(files)
+		scn.Follow(sources)
 	}
 }
 
-func Version() string {
+func cliVersion() string {
 	if version != "dev" {
 		return version
 	}
@@ -161,4 +161,15 @@ func Version() string {
 	}
 
 	return "dev"
+}
+
+func printEntries(entries []domain.LogEntry) {
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].Timestamp.Before(entries[j].Timestamp)
+	})
+
+	f := formatter.NewFormatter(entries)
+	for _, e := range entries {
+		fmt.Println(f.Format(e))
+	}
 }

--- a/cmd/reqlog/main.go
+++ b/cmd/reqlog/main.go
@@ -141,7 +141,7 @@ func main() {
 	}
 
 	entries := scn.Scan(sources)
-	f := formatter.NewFormatter(entries)
+	f := formatter.NewFormatter(entries, keys)
 
 	printEntries(f, entries)
 

--- a/cmd/reqlog/main.go
+++ b/cmd/reqlog/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"log"
@@ -139,10 +140,13 @@ func main() {
 		log.Fatal("no matching sources found")
 	}
 
-	printEntries(scn.Scan(sources))
+	entries := scn.Scan(sources)
+	f := formatter.NewFormatter(entries)
+
+	printEntries(f, entries)
 
 	if *follow {
-		scn.Follow(sources)
+		scn.Follow(context.Background(), sources, f)
 	}
 }
 
@@ -163,12 +167,11 @@ func cliVersion() string {
 	return "dev"
 }
 
-func printEntries(entries []domain.LogEntry) {
+func printEntries(f formatter.LogFormatter, entries []domain.LogEntry) {
 	sort.Slice(entries, func(i, j int) bool {
 		return entries[i].Timestamp.Before(entries[j].Timestamp)
 	})
 
-	f := formatter.NewFormatter(entries)
 	for _, e := range entries {
 		fmt.Println(f.Format(e))
 	}

--- a/internal/docker/client.go
+++ b/internal/docker/client.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 )
 
+var execCommand = exec.Command
+
 type DockerCLIClient struct{}
 
 func NewDockerCLIClient() *DockerCLIClient {
@@ -26,7 +28,7 @@ func (c *DockerCLIClient) Logs(container string, follow bool, since string) (io.
 
 	args = append(args, container)
 
-	cmd := exec.Command("docker", args...)
+	cmd := execCommand("docker", args...)
 
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
@@ -47,7 +49,7 @@ func (c *DockerCLIClient) Logs(container string, follow bool, since string) (io.
 }
 
 func (c *DockerCLIClient) ListContainers() ([]string, error) {
-	cmd := exec.Command("docker", "ps", "--format", "{{.Names}}")
+	cmd := execCommand("docker", "ps", "--format", "{{.Names}}")
 
 	out, err := cmd.Output()
 	if err != nil {

--- a/internal/docker/client.go
+++ b/internal/docker/client.go
@@ -1,0 +1,68 @@
+package docker
+
+import (
+	"fmt"
+	"io"
+	"os/exec"
+	"strings"
+)
+
+type DefaultCLIDockerClient struct{}
+
+func NewCLIDockerClient() *DefaultCLIDockerClient {
+	return &DefaultCLIDockerClient{}
+}
+
+func (c *DefaultCLIDockerClient) Logs(container string, follow bool, since string) (io.ReadCloser, error) {
+	args := []string{"logs"}
+
+	if follow {
+		args = append(args, "--follow", "--tail", "0")
+	}
+
+	if since != "" {
+		args = append(args, "--since", since)
+	}
+
+	args = append(args, container)
+
+	cmd := exec.Command("docker", args...)
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, err
+	}
+
+	// Docker logs go to stderr by default
+	cmd.Stderr = cmd.Stdout
+
+	if err := cmd.Start(); err != nil {
+		return nil, err
+	}
+
+	return &CMDReadCloser{
+		ReadCloser: stdout,
+		cmd:        cmd,
+	}, nil
+}
+
+func (c *DefaultCLIDockerClient) ListContainers() ([]string, error) {
+	cmd := exec.Command("docker", "ps", "--format", "{{.Names}}")
+
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("docker ps failed: %v", err)
+	}
+
+	lines := strings.Split(strings.TrimSpace(string(out)), "\n")
+
+	var containers []string
+	for _, l := range lines {
+		l = strings.TrimSpace(l)
+		if l != "" {
+			containers = append(containers, l)
+		}
+	}
+
+	return containers, nil
+}

--- a/internal/docker/client.go
+++ b/internal/docker/client.go
@@ -7,13 +7,13 @@ import (
 	"strings"
 )
 
-type DefaultCLIDockerClient struct{}
+type DockerCLIClient struct{}
 
-func NewCLIDockerClient() *DefaultCLIDockerClient {
-	return &DefaultCLIDockerClient{}
+func NewDockerCLIClient() *DockerCLIClient {
+	return &DockerCLIClient{}
 }
 
-func (c *DefaultCLIDockerClient) Logs(container string, follow bool, since string) (io.ReadCloser, error) {
+func (c *DockerCLIClient) Logs(container string, follow bool, since string) (io.ReadCloser, error) {
 	args := []string{"logs"}
 
 	if follow {
@@ -46,7 +46,7 @@ func (c *DefaultCLIDockerClient) Logs(container string, follow bool, since strin
 	}, nil
 }
 
-func (c *DefaultCLIDockerClient) ListContainers() ([]string, error) {
+func (c *DockerCLIClient) ListContainers() ([]string, error) {
 	cmd := exec.Command("docker", "ps", "--format", "{{.Names}}")
 
 	out, err := cmd.Output()

--- a/internal/docker/client_test.go
+++ b/internal/docker/client_test.go
@@ -1,0 +1,156 @@
+package docker
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"reflect"
+	"testing"
+)
+
+func fakeExecCommand(output string, err error) *exec.Cmd {
+	cmd := exec.Command(os.Args[0], "-test.run=TestHelperProcess", "--")
+	cmd.Env = []string{
+		"GO_WANT_HELPER_PROCESS=1",
+		"OUTPUT=" + output,
+		"ERR=" + fmt.Sprint(err != nil),
+	}
+	return cmd
+}
+
+func TestHelperProcess(t *testing.T) {
+	if os.Getenv("GO_WANT_HELPER_PROCESS") != "1" {
+		return
+	}
+
+	if os.Getenv("ERR") == "true" {
+		os.Exit(1)
+	}
+
+	fmt.Fprint(os.Stdout, os.Getenv("OUTPUT"))
+	os.Exit(0)
+}
+
+func TestDockerCLIClient_ListContainers(t *testing.T) {
+	tests := []struct {
+		name      string
+		output    string
+		err       error
+		want      []string
+		expectErr bool
+	}{
+		{
+			name:   "multiple containers",
+			output: "auth\nsvc\nworker\n",
+			want:   []string{"auth", "svc", "worker"},
+		},
+		{
+			name:   "empty lines trimmed",
+			output: "\nauth\n\nsvc\n",
+			want:   []string{"auth", "svc"},
+		},
+		{
+			name:      "command error",
+			err:       fmt.Errorf("docker not found"),
+			expectErr: true,
+		},
+	}
+
+	orig := execCommand
+	defer func() { execCommand = orig }()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			execCommand = func(name string, args ...string) *exec.Cmd {
+				return fakeExecCommand(tt.output, tt.err)
+			}
+
+			c := NewDockerCLIClient()
+
+			res, err := c.ListContainers()
+
+			if tt.expectErr {
+				if err == nil {
+					t.Fatalf("expected error")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if !reflect.DeepEqual(res, tt.want) {
+				t.Fatalf("expected %v, got %v", tt.want, res)
+			}
+		})
+	}
+}
+
+func TestDockerCLIClient_Logs_Args(t *testing.T) {
+	tests := []struct {
+		name     string
+		follow   bool
+		since    string
+		expected []string
+	}{
+		{
+			name:   "basic logs",
+			follow: false,
+			since:  "",
+			expected: []string{
+				"logs", "auth",
+			},
+		},
+		{
+			name:   "follow enabled",
+			follow: true,
+			since:  "",
+			expected: []string{
+				"logs", "--follow", "--tail", "0", "auth",
+			},
+		},
+		{
+			name:   "since provided",
+			follow: false,
+			since:  "5m",
+			expected: []string{
+				"logs", "--since", "5m", "auth",
+			},
+		},
+		{
+			name:   "follow + since",
+			follow: true,
+			since:  "5m",
+			expected: []string{
+				"logs", "--follow", "--tail", "0", "--since", "5m", "auth",
+			},
+		},
+	}
+
+	orig := execCommand
+	defer func() { execCommand = orig }()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var capturedArgs []string
+
+			execCommand = func(name string, args ...string) *exec.Cmd {
+				capturedArgs = args
+				return fakeExecCommand("log line\n", nil)
+			}
+
+			c := NewDockerCLIClient()
+
+			rc, err := c.Logs("auth", tt.follow, tt.since)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			defer rc.Close()
+
+			if !reflect.DeepEqual(capturedArgs, tt.expected) {
+				t.Fatalf("expected args %v, got %v", tt.expected, capturedArgs)
+			}
+		})
+	}
+}

--- a/internal/docker/cmd_read_closer.go
+++ b/internal/docker/cmd_read_closer.go
@@ -1,0 +1,21 @@
+package docker
+
+import (
+	"io"
+	"os/exec"
+)
+
+type CMDReadCloser struct {
+	io.ReadCloser
+	cmd *exec.Cmd
+}
+
+func (c *CMDReadCloser) Close() error {
+	err := c.ReadCloser.Close()
+	waitErr := c.cmd.Wait()
+
+	if err != nil {
+		return err
+	}
+	return waitErr
+}

--- a/internal/docker/cmd_read_closer_test.go
+++ b/internal/docker/cmd_read_closer_test.go
@@ -1,0 +1,32 @@
+package docker
+
+import (
+	"io"
+	"os/exec"
+	"testing"
+)
+
+func TestCMDReadCloser_Close(t *testing.T) {
+	cmd := exec.Command("echo", "test")
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+
+	rc := &CMDReadCloser{
+		ReadCloser: stdout,
+		cmd:        cmd,
+	}
+
+	// drain stdout to avoid broken pipe
+	_, _ = io.ReadAll(rc)
+
+	if err := rc.Close(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/internal/docker/interface.go
+++ b/internal/docker/interface.go
@@ -1,0 +1,8 @@
+package docker
+
+import "io"
+
+type CLIDockerClient interface {
+	Logs(container string, follow bool, since string) (io.ReadCloser, error)
+	ListContainers() ([]string, error)
+}

--- a/internal/docker/interface.go
+++ b/internal/docker/interface.go
@@ -2,7 +2,7 @@ package docker
 
 import "io"
 
-type CLIDockerClient interface {
+type DockerClient interface {
 	Logs(container string, follow bool, since string) (io.ReadCloser, error)
 	ListContainers() ([]string, error)
 }

--- a/internal/formatter/colorizer.go
+++ b/internal/formatter/colorizer.go
@@ -35,9 +35,15 @@ var colors = []string{
 const (
 	reset = "\033[0m"
 	dim   = "\033[2m"
+	bold  = "\033[1m"
 
 	tsColor  = "\033[38;5;245m" // gray
 	msgColor = "\033[38;5;252m" // near white
+
+	red    = "\033[31m"
+	green  = "\033[32m"
+	yellow = "\033[33m"
+	cyan   = "\033[36m"
 )
 
 type Colorizer struct{}
@@ -57,6 +63,26 @@ func (c *Colorizer) Color(service string) string {
 	h ^= h >> 16
 
 	return colors[int(h)%len(colors)]
+}
+
+func (c *Colorizer) Cyan(s string) string {
+	return cyan + s + reset
+}
+
+func (c *Colorizer) Green(s string) string {
+	return green + s + reset
+}
+
+func (c *Colorizer) Red(s string) string {
+	return red + s + reset
+}
+
+func (c *Colorizer) Yellow(s string) string {
+	return yellow + s + reset
+}
+
+func (c *Colorizer) Bold(s string) string {
+	return bold + s + reset
 }
 
 func fnv32a(text string) uint32 {

--- a/internal/formatter/formatter.go
+++ b/internal/formatter/formatter.go
@@ -2,6 +2,8 @@ package formatter
 
 import (
 	"fmt"
+	"slices"
+	"sort"
 	"strings"
 	"time"
 
@@ -11,9 +13,10 @@ import (
 type Formatter struct {
 	colorizer    *Colorizer
 	serviceWidth int
+	searchKeys   []string
 }
 
-func NewFormatter(entries []domain.LogEntry) *Formatter {
+func NewFormatter(entries []domain.LogEntry, searchKeys []string) *Formatter {
 	max := 0
 	for _, e := range entries {
 		if len(e.Service) > max {
@@ -24,6 +27,7 @@ func NewFormatter(entries []domain.LogEntry) *Formatter {
 	return &Formatter{
 		colorizer:    NewColorizer(),
 		serviceWidth: max,
+		searchKeys:   searchKeys,
 	}
 }
 
@@ -50,7 +54,139 @@ func (f *Formatter) Format(entry domain.LogEntry) string {
 		padding,
 
 		msgColor,
-		entry.Message,
+		f.formatMessage(entry.Message),
 		reset,
 	)
+}
+
+func (f *Formatter) colorLevel(val string) string {
+	switch strings.ToLower(val) {
+	case "error":
+		return f.colorizer.Red(val)
+	case "warn", "warning":
+		return f.colorizer.Yellow(val)
+	default:
+		return val
+	}
+}
+
+func (f *Formatter) highlightKey(key string) string {
+	if slices.Contains(f.searchKeys, key) {
+		return f.colorizer.Bold(key)
+	}
+	return key
+}
+
+func (f *Formatter) formatMessage(msg string) string {
+	mainMsg, pairs := parseMessage(msg)
+
+	var kvParts []string
+
+	for _, p := range pairs {
+		key := p.key
+		val := p.value
+
+		if key == "level" {
+			val = f.colorLevel(val)
+		}
+
+		key = f.highlightKey(key)
+
+		kvParts = append(kvParts,
+			fmt.Sprintf("%s=%s",
+				f.colorizer.Cyan(key),
+				val,
+			),
+		)
+	}
+
+	if len(kvParts) == 0 {
+		return mainMsg
+	}
+
+	if mainMsg == "" {
+		return fmt.Sprintf("%s", strings.Join(kvParts, ""))
+	}
+
+	return fmt.Sprintf("%s %s", mainMsg, strings.Join(kvParts, " "))
+}
+
+type kv struct {
+	key   string
+	value string
+}
+
+func parseMessage(msg string) (string, []kv) {
+	parts := strings.Fields(msg)
+
+	var pairs []kv
+	var messageParts []string
+
+	i := 0
+	for i < len(parts) {
+		part := parts[i]
+
+		if strings.Contains(part, "=") {
+			split := strings.SplitN(part, "=", 2)
+			key := split[0]
+			value := split[1]
+
+			j := i + 1
+			for j < len(parts) && !strings.Contains(parts[j], "=") {
+				value += " " + parts[j]
+				j++
+			}
+
+			pairs = append(pairs, kv{key, value})
+			i = j
+			continue
+		}
+
+		messageParts = append(messageParts, part)
+		i++
+	}
+
+	var mainMsg string
+	filtered := make([]kv, 0, len(pairs))
+
+	for _, p := range pairs {
+		if p.key == "message" || p.key == "msg" {
+			mainMsg = p.value
+			continue
+		}
+		filtered = append(filtered, p)
+	}
+
+	if mainMsg == "" {
+		mainMsg = strings.Join(messageParts, " ")
+	}
+
+	filtered = sortKVByPriority(filtered)
+
+	return mainMsg, filtered
+}
+
+var keyPriority = map[string]int{
+	"level":      1,
+	"request_id": 2,
+}
+
+func sortKVByPriority(pairs []kv) []kv {
+	priority := func(key string) int {
+		if val, ok := keyPriority[key]; ok {
+			return val
+		}
+		return 99
+	}
+
+	sort.SliceStable(pairs, func(i, j int) bool {
+		pi := priority(pairs[i].key)
+		pj := priority(pairs[j].key)
+		if pi != pj {
+			return pi < pj
+		}
+		return pairs[i].key < pairs[j].key
+	})
+
+	return pairs
 }

--- a/internal/formatter/formatter_test.go
+++ b/internal/formatter/formatter_test.go
@@ -1,6 +1,7 @@
 package formatter
 
 import (
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -8,40 +9,79 @@ import (
 	"github.com/sagarmaheshwary/reqlog/internal/domain"
 )
 
-func TestNewFormatter_ServiceWidth(t *testing.T) {
-	entries := []domain.LogEntry{
-		{Service: "api"},
-		{Service: "order-service"},
-		{Service: "inv"},
+func TestParseMessage_RemovesMessageKey(t *testing.T) {
+	msg := "level=info message=Hello request_id=abc123 extra=xyz"
+	main, pairs := parseMessage(msg)
+
+	if main != "Hello" {
+		t.Fatalf("expected main message 'Hello', got %q", main)
 	}
 
-	f := NewFormatter(entries)
+	for _, p := range pairs {
+		if p.key == "message" || p.key == "msg" {
+			t.Fatalf("message key should be removed from pairs")
+		}
+	}
 
-	expected := len("order-service")
-	if f.serviceWidth != expected {
-		t.Fatalf("expected serviceWidth %d, got %d", expected, f.serviceWidth)
+	if len(pairs) != 3 { // level, request_id, extra
+		t.Fatalf("expected 3 kv pairs, got %d", len(pairs))
 	}
 }
 
-func TestPadAfter(t *testing.T) {
-	f := &Formatter{serviceWidth: 10}
+func TestParseMessage_SortsByPriority(t *testing.T) {
+	msg := "extra=foo request_id=abc123 level=warn alpha=bar"
+	_, pairs := parseMessage(msg)
 
-	tests := []struct {
-		service  string
-		expected int // expected number of spaces
-	}{
-		{"api", 7},
-		{"service", 3},
-		{"verylongsvc", 0}, // longer than width → no padding
+	if pairs[0].key != "level" {
+		t.Fatalf("expected first key 'level', got %q", pairs[0].key)
+	}
+	if pairs[1].key != "request_id" {
+		t.Fatalf("expected second key 'request_id', got %q", pairs[1].key)
+	}
+	// rest are sorted alphabetically
+	if pairs[2].key != "alpha" || pairs[3].key != "extra" {
+		t.Fatalf("expected remaining keys sorted alphabetically, got %v", pairs[2:])
+	}
+}
+
+func TestFormat_HighlightSearchKey(t *testing.T) {
+	entry := domain.LogEntry{
+		Timestamp: time.Now(),
+		Service:   "api",
+		Message:   "request_id=abc123 level=info message=hello",
 	}
 
-	for _, tt := range tests {
-		padding := f.padAfter(tt.service)
+	f := &Formatter{
+		colorizer:    NewColorizer(),
+		searchKeys:   []string{"request_id"},
+		serviceWidth: len("api"),
+	}
 
-		if len(padding) != tt.expected {
-			t.Fatalf("service=%s expected padding %d, got %d",
-				tt.service, tt.expected, len(padding))
-		}
+	out := f.Format(entry)
+
+	// Ensure the search key is bold (contains ANSI code for bold)
+	if !strings.Contains(out, "\033[1mrequest_id\033[0m") {
+		t.Fatalf("expected search key 'request_id' to be bold")
+	}
+}
+
+func TestFormat_ColorLevel(t *testing.T) {
+	entry := domain.LogEntry{
+		Timestamp: time.Now(),
+		Service:   "api",
+		Message:   "level=error message=fail",
+	}
+
+	f := &Formatter{
+		colorizer:    NewColorizer(),
+		searchKeys:   nil,
+		serviceWidth: len("api"),
+	}
+
+	out := f.Format(entry)
+
+	if !strings.Contains(out, f.colorizer.Red("error")) {
+		t.Fatalf("expected 'error' to be colored red")
 	}
 }
 
@@ -51,7 +91,7 @@ func TestFormat_OutputStructure(t *testing.T) {
 	entry := domain.LogEntry{
 		Timestamp: ts,
 		Service:   "api",
-		Message:   "test message",
+		Message:   "level=info message=test request_id=xyz",
 	}
 
 	entries := []domain.LogEntry{
@@ -59,7 +99,7 @@ func TestFormat_OutputStructure(t *testing.T) {
 		{Service: "longer-service"},
 	}
 
-	f := NewFormatter(entries)
+	f := NewFormatter(entries, []string{"request_id"})
 
 	out := f.Format(entry)
 
@@ -71,42 +111,132 @@ func TestFormat_OutputStructure(t *testing.T) {
 		t.Fatalf("expected service [api] in output")
 	}
 
-	if !strings.Contains(out, "test message") {
-		t.Fatalf("expected message in output")
+	if !strings.Contains(out, "test") {
+		t.Fatalf("expected main message 'test' in output")
 	}
 
 	if !strings.Contains(out, " | ") {
-		t.Fatalf("expected ' | ' separator in output")
+		t.Fatalf("expected ' | ' separator")
+	}
+
+	// Ensure key/value parts include request_id
+	if !strings.Contains(out, "request_id") {
+		t.Fatalf("expected 'request_id' in output")
 	}
 }
 
-func TestFormat_Alignment(t *testing.T) {
-	ts := time.Now()
-
-	entries := []domain.LogEntry{
-		{Timestamp: ts, Service: "api", Message: "one"},
-		{Timestamp: ts, Service: "longer-service", Message: "two"},
+func TestParseMessage(t *testing.T) {
+	tests := []struct {
+		name         string
+		input        string
+		wantMainMsg  string
+		wantKVKeys   []string
+		wantKVValues []string
+	}{
+		{
+			name:         "message key removed and main msg extracted",
+			input:        "level=info message=Hello request_id=abc123 extra=xyz",
+			wantMainMsg:  "Hello",
+			wantKVKeys:   []string{"level", "request_id", "extra"},
+			wantKVValues: []string{"info", "abc123", "xyz"},
+		},
+		{
+			name:         "no message key, text treated as main message",
+			input:        "just some log text level=warn",
+			wantMainMsg:  "just some log text",
+			wantKVKeys:   []string{"level"},
+			wantKVValues: []string{"warn"},
+		},
+		{
+			name:         "message key with spaces preserved",
+			input:        "message=Hello world level=info request_id=xyz",
+			wantMainMsg:  "Hello world",
+			wantKVKeys:   []string{"level", "request_id"},
+			wantKVValues: []string{"info", "xyz"},
+		},
+		{
+			name:         "multiline value handled",
+			input:        "time_taken=13ms message=hit level=info",
+			wantMainMsg:  "hit",
+			wantKVKeys:   []string{"level", "time_taken"},
+			wantKVValues: []string{"info", "13ms"},
+		},
 	}
 
-	f := NewFormatter(entries)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mainMsg, kvs := parseMessage(tt.input)
 
-	out1 := f.Format(entries[0])
-	out2 := f.Format(entries[1])
+			if mainMsg != tt.wantMainMsg {
+				t.Errorf("mainMsg = %q; want %q", mainMsg, tt.wantMainMsg)
+			}
 
-	i1 := strings.Index(out1, "|")
-	i2 := strings.Index(out2, "|")
+			if len(kvs) != len(tt.wantKVKeys) {
+				t.Fatalf("got %d kv pairs, want %d", len(kvs), len(tt.wantKVKeys))
+			}
 
-	if i1 != i2 {
-		t.Fatalf("expected aligned pipes, got %d and %d", i1, i2)
+			for i, kv := range kvs {
+				if kv.key != tt.wantKVKeys[i] || kv.value != tt.wantKVValues[i] {
+					t.Errorf("kv[%d] = {%q, %q}; want {%q, %q}", i, kv.key, kv.value, tt.wantKVKeys[i], tt.wantKVValues[i])
+				}
+			}
+		})
 	}
 }
 
-func TestPadAfter_NoPaddingNeeded(t *testing.T) {
-	f := &Formatter{serviceWidth: 3}
+func TestSortKVByPriority(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []kv
+		expected []kv
+	}{
+		{
+			name: "prioritizes level then request_id",
+			input: []kv{
+				{key: "extra", value: "foo"},
+				{key: "request_id", value: "abc"},
+				{key: "level", value: "warn"},
+			},
+			expected: []kv{
+				{key: "level", value: "warn"},
+				{key: "request_id", value: "abc"},
+				{key: "extra", value: "foo"},
+			},
+		},
+		{
+			name: "alphabetical fallback for equal priority",
+			input: []kv{
+				{key: "zeta", value: "1"},
+				{key: "alpha", value: "2"},
+			},
+			expected: []kv{
+				{key: "alpha", value: "2"},
+				{key: "zeta", value: "1"},
+			},
+		},
+		{
+			name: "mixed priority and alphabetical",
+			input: []kv{
+				{key: "beta", value: "b"},
+				{key: "level", value: "info"},
+				{key: "request_id", value: "r1"},
+				{key: "alpha", value: "a"},
+			},
+			expected: []kv{
+				{key: "level", value: "info"},
+				{key: "request_id", value: "r1"},
+				{key: "alpha", value: "a"},
+				{key: "beta", value: "b"},
+			},
+		},
+	}
 
-	padding := f.padAfter("abcd")
-
-	if padding != "" {
-		t.Fatalf("expected no padding, got %q", padding)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := sortKVByPriority(tt.input)
+			if !reflect.DeepEqual(got, tt.expected) {
+				t.Errorf("got %v; want %v", got, tt.expected)
+			}
+		})
 	}
 }

--- a/internal/formatter/interface.go
+++ b/internal/formatter/interface.go
@@ -1,0 +1,7 @@
+package formatter
+
+import "github.com/sagarmaheshwary/reqlog/internal/domain"
+
+type LogFormatter interface {
+	Format(entry domain.LogEntry) string
+}

--- a/internal/parser/factory.go
+++ b/internal/parser/factory.go
@@ -5,20 +5,16 @@ import "fmt"
 type ParserType string
 
 const (
-	TypeText   ParserType = "text"
-	TypeJSON   ParserType = "json"
-	TypeDocker ParserType = "docker"
+	TypeText ParserType = "text"
+	TypeJSON ParserType = "json"
 )
 
-func NewParser(t ParserType) (LogParser, error) {
+func New(t ParserType) (LogParser, error) {
 	switch t {
 	case TypeText:
 		return TextParser{}, nil
 	case TypeJSON:
 		return JSONParser{}, nil
-	case TypeDocker:
-		// future
-		return nil, fmt.Errorf("docker parser not implemented yet")
 	default:
 		return nil, fmt.Errorf("unknown parser type")
 	}

--- a/internal/parser/factory_test.go
+++ b/internal/parser/factory_test.go
@@ -2,47 +2,66 @@ package parser
 
 import "testing"
 
-func TestNewParser_Text(t *testing.T) {
-	p, err := NewParser(TypeText)
-	if err != nil {
-		t.Fatalf("expected no error, got %v", err)
+func TestNewParser(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   ParserType
+		wantErr bool
+		check   func(t *testing.T, p LogParser)
+	}{
+		{
+			name:  "text parser",
+			input: TypeText,
+			check: func(t *testing.T, p LogParser) {
+				if _, ok := p.(TextParser); !ok {
+					t.Fatalf("expected TextParser, got %T", p)
+				}
+			},
+		},
+		{
+			name:  "json parser",
+			input: TypeJSON,
+			check: func(t *testing.T, p LogParser) {
+				if _, ok := p.(JSONParser); !ok {
+					t.Fatalf("expected JSONParser, got %T", p)
+				}
+			},
+		},
+		{
+			name:    "unknown parser",
+			input:   ParserType("xml"),
+			wantErr: true,
+		},
 	}
 
-	if p == nil {
-		t.Fatal("expected parser, got nil")
-	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p, err := New(tt.input)
 
-	if _, ok := p.(TextParser); !ok {
-		t.Fatalf("expected TextParser, got %T", p)
-	}
-}
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				if p != nil {
+					t.Fatalf("expected nil parser, got %T", p)
+				}
+				if err.Error() != "unknown parser type" {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				return
+			}
 
-func TestNewParser_JSON(t *testing.T) {
-	p, err := NewParser(TypeJSON)
-	if err != nil {
-		t.Fatalf("expected no error, got %v", err)
-	}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
 
-	if p == nil {
-		t.Fatal("expected parser, got nil")
-	}
+			if p == nil {
+				t.Fatal("expected parser, got nil")
+			}
 
-	if _, ok := p.(JSONParser); !ok {
-		t.Fatalf("expected JSONParser, got %T", p)
-	}
-}
-
-func TestNewParser_UnknownType(t *testing.T) {
-	p, err := NewParser(ParserType("xml"))
-	if err == nil {
-		t.Fatal("expected error, got nil")
-	}
-
-	if p != nil {
-		t.Fatalf("expected nil parser, got %T", p)
-	}
-
-	if err.Error() != "unknown parser type" {
-		t.Fatalf("unexpected error: %v", err)
+			if tt.check != nil {
+				tt.check(t, p)
+			}
+		})
 	}
 }

--- a/internal/scanner/docker_scanner.go
+++ b/internal/scanner/docker_scanner.go
@@ -3,8 +3,11 @@ package scanner
 import (
 	"bufio"
 	"container/heap"
+	"context"
 	"fmt"
+	"io"
 	"strings"
+	"sync"
 
 	"github.com/sagarmaheshwary/reqlog/internal/docker"
 	"github.com/sagarmaheshwary/reqlog/internal/domain"
@@ -13,11 +16,22 @@ import (
 
 type DockerScanner struct {
 	lineProcessor *LineProcessor
-	dockerClient  docker.CLIDockerClient
+	dockerClient  docker.DockerClient
+	out           io.Writer
+	errOut        io.Writer
 }
 
-func NewDockerScanner(lp *LineProcessor, client docker.CLIDockerClient) *DockerScanner {
-	return &DockerScanner{lineProcessor: lp, dockerClient: client}
+func NewDockerScanner(lp *LineProcessor,
+	client docker.DockerClient,
+	out io.Writer,
+	errOut io.Writer,
+) *DockerScanner {
+	return &DockerScanner{
+		lineProcessor: lp,
+		dockerClient:  client,
+		out:           out,
+		errOut:        errOut,
+	}
 }
 
 func (ds *DockerScanner) Scan(containers []string) []domain.LogEntry {
@@ -34,19 +48,22 @@ func (ds *DockerScanner) Scan(containers []string) []domain.LogEntry {
 	for _, container := range containers {
 		reader, err := ds.dockerClient.Logs(container, false, cfg.Since)
 		if err != nil {
-			logScanError(container, err)
+			logScanError(ds.errOut, container, err)
 			continue
 		}
-		defer reader.Close()
 
-		scanner := bufio.NewScanner(reader)
-		for scanner.Scan() {
-			line := scanner.Text()
-			entry, ok := ds.lineProcessor.ProcessLine(line, container)
-			if ok && passesSince(entry, sinceTime) {
-				ds.lineProcessor.AddEntry(*entry, &results, &h)
+		func() {
+			defer reader.Close()
+
+			scanner := bufio.NewScanner(reader)
+			for scanner.Scan() {
+				line := scanner.Text()
+				entry, ok := ds.lineProcessor.ProcessLine(line, container)
+				if ok && passesSince(entry, sinceTime) {
+					ds.lineProcessor.AddEntry(*entry, &results, &h)
+				}
 			}
-		}
+		}()
 	}
 
 	if cfg.Limit > 0 {
@@ -56,16 +73,17 @@ func (ds *DockerScanner) Scan(containers []string) []domain.LogEntry {
 	return results
 }
 
-func (ds *DockerScanner) Follow(containers []string) {
-	f := formatter.NewFormatter([]domain.LogEntry{})
-
-	done := make(chan struct{})
+func (ds *DockerScanner) Follow(ctx context.Context, containers []string, f formatter.LogFormatter) {
+	var wg sync.WaitGroup
 
 	for _, container := range containers {
+		wg.Add(1)
 		go func(container string) {
+			defer wg.Done()
+
 			reader, err := ds.dockerClient.Logs(container, true, "")
 			if err != nil {
-				logScanError(container, err)
+				logScanError(ds.errOut, container, err)
 				return
 			}
 			defer reader.Close()
@@ -74,15 +92,23 @@ func (ds *DockerScanner) Follow(containers []string) {
 			for scanner.Scan() {
 				line := scanner.Text()
 				entry, ok := ds.lineProcessor.ProcessLine(line, container)
-				if !ok {
-					continue
+				if ok {
+					fmt.Fprintln(ds.out, f.Format(*entry))
 				}
-				fmt.Println(f.Format(*entry))
 			}
 		}(container)
 	}
 
-	<-done
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-ctx.Done():
+	case <-done:
+	}
 }
 
 func (ds *DockerScanner) ListSources() ([]string, error) {

--- a/internal/scanner/docker_scanner.go
+++ b/internal/scanner/docker_scanner.go
@@ -1,0 +1,23 @@
+package scanner
+
+import "github.com/sagarmaheshwary/reqlog/internal/domain"
+
+type DockerScanner struct {
+	lineProcessor *LineProcessor
+}
+
+func NewDockerScanner(lp *LineProcessor) *DockerScanner {
+	return &DockerScanner{lineProcessor: lp}
+}
+
+func (ds *DockerScanner) Scan(containers []string) []domain.LogEntry {
+	return nil
+}
+
+func (ds *DockerScanner) Follow(containers []string) {
+	//
+}
+
+func (ds *DockerScanner) ListSources() ([]string, error) {
+	return nil, nil
+}

--- a/internal/scanner/docker_scanner.go
+++ b/internal/scanner/docker_scanner.go
@@ -1,23 +1,135 @@
 package scanner
 
-import "github.com/sagarmaheshwary/reqlog/internal/domain"
+import (
+	"bufio"
+	"container/heap"
+	"fmt"
+	"strings"
+
+	"github.com/sagarmaheshwary/reqlog/internal/docker"
+	"github.com/sagarmaheshwary/reqlog/internal/domain"
+	"github.com/sagarmaheshwary/reqlog/internal/formatter"
+)
 
 type DockerScanner struct {
 	lineProcessor *LineProcessor
+	dockerClient  docker.CLIDockerClient
 }
 
-func NewDockerScanner(lp *LineProcessor) *DockerScanner {
-	return &DockerScanner{lineProcessor: lp}
+func NewDockerScanner(lp *LineProcessor, client docker.CLIDockerClient) *DockerScanner {
+	return &DockerScanner{lineProcessor: lp, dockerClient: client}
 }
 
 func (ds *DockerScanner) Scan(containers []string) []domain.LogEntry {
-	return nil
+	cfg := ds.lineProcessor.config
+
+	var h entryHeap
+	var results []domain.LogEntry
+	sinceTime := parseSince(ds.lineProcessor.config.Since)
+
+	if cfg.Limit > 0 {
+		heap.Init(&h)
+	}
+
+	for _, container := range containers {
+		reader, err := ds.dockerClient.Logs(container, false, cfg.Since)
+		if err != nil {
+			logScanError(container, err)
+			continue
+		}
+		defer reader.Close()
+
+		scanner := bufio.NewScanner(reader)
+		for scanner.Scan() {
+			line := scanner.Text()
+			entry, ok := ds.lineProcessor.ProcessLine(line, container)
+			if ok && passesSince(entry, sinceTime) {
+				ds.lineProcessor.AddEntry(*entry, &results, &h)
+			}
+		}
+	}
+
+	if cfg.Limit > 0 {
+		results = drainHeap(&h)
+	}
+
+	return results
 }
 
 func (ds *DockerScanner) Follow(containers []string) {
-	//
+	f := formatter.NewFormatter([]domain.LogEntry{})
+
+	done := make(chan struct{})
+
+	for _, container := range containers {
+		go func(container string) {
+			reader, err := ds.dockerClient.Logs(container, true, "")
+			if err != nil {
+				logScanError(container, err)
+				return
+			}
+			defer reader.Close()
+
+			scanner := bufio.NewScanner(reader)
+			for scanner.Scan() {
+				line := scanner.Text()
+				entry, ok := ds.lineProcessor.ProcessLine(line, container)
+				if !ok {
+					continue
+				}
+				fmt.Println(f.Format(*entry))
+			}
+		}(container)
+	}
+
+	<-done
 }
 
 func (ds *DockerScanner) ListSources() ([]string, error) {
-	return nil, nil
+	containers, err := ds.dockerClient.ListContainers()
+	if err != nil {
+		return nil, err
+	}
+
+	exact := map[string]struct{}{}
+	prefixes := []string{}
+
+	for _, s := range ds.lineProcessor.config.Services {
+		s = strings.TrimSpace(s)
+		if s == "" {
+			continue
+		}
+		if before, ok := strings.CutSuffix(s, "*"); ok {
+			prefixes = append(prefixes, before)
+		} else {
+			exact[s] = struct{}{}
+		}
+	}
+
+	matchesService := func(name string) bool {
+		if len(exact) == 0 && len(prefixes) == 0 {
+			return true
+		}
+		if _, ok := exact[name]; ok {
+			return true
+		}
+
+		for _, p := range prefixes {
+			if strings.HasPrefix(name, p) {
+				return true
+			}
+		}
+		return false
+	}
+
+	matches := make([]string, 0, len(containers))
+	for _, name := range containers {
+		if !matchesService(name) {
+			continue
+		}
+
+		matches = append(matches, name)
+	}
+
+	return matches, nil
 }

--- a/internal/scanner/docker_scanner_test.go
+++ b/internal/scanner/docker_scanner_test.go
@@ -1,0 +1,372 @@
+package scanner
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sagarmaheshwary/reqlog/internal/docker"
+	"github.com/sagarmaheshwary/reqlog/internal/domain"
+	"github.com/sagarmaheshwary/reqlog/internal/parser"
+)
+
+var errTest = errors.New("docker error")
+
+func dockerLogs(lines []string) io.ReadCloser {
+	return io.NopCloser(strings.NewReader(strings.Join(lines, "\n")))
+}
+
+func newTestDockerScanner(cfg *ScanConfig, p parser.LogParser, client docker.DockerClient) *DockerScanner {
+	lp := NewLineProcessor(cfg, p)
+	return NewDockerScanner(lp, client, io.Discard, io.Discard)
+}
+
+func TestDockerScanner_Scan(t *testing.T) {
+	now := time.Now().UTC()
+	oldTime := now.Add(-10 * time.Minute).Format(time.RFC3339)
+	newTime := now.Add(-1 * time.Minute).Format(time.RFC3339)
+
+	tests := []struct {
+		name       string
+		logsFn     func(container string, follow bool, since string) (io.ReadCloser, error)
+		cfg        *ScanConfig
+		containers []string
+		want       int
+		wantErrLog string
+	}{
+		{
+			name: "single container logs",
+			logsFn: func(container string, follow bool, since string) (io.ReadCloser, error) {
+				return dockerLogs([]string{
+					"2024-03-10T12:00:00Z user=123 status=ok",
+					"2024-03-10T12:01:00Z user=456 status=fail",
+					"2024-03-10T12:02:00Z user=123 status=ok",
+				}), nil
+			},
+			cfg:        &ScanConfig{SearchValue: "123", Keys: []string{"user"}},
+			containers: []string{"auth"},
+			want:       2,
+		},
+		{
+			name: "with since filter",
+			logsFn: func(container string, follow bool, since string) (io.ReadCloser, error) {
+				return dockerLogs([]string{
+					oldTime + " user=123",
+					newTime + " user=123",
+				}), nil
+			},
+			cfg:        &ScanConfig{SearchValue: "123", Keys: []string{"user"}, Since: "5m"},
+			containers: []string{"svc"},
+			want:       1,
+		},
+		{
+			name: "ignore case",
+			logsFn: func(container string, follow bool, since string) (io.ReadCloser, error) {
+				return dockerLogs([]string{"2024-03-10T12:00:00Z user=ABC"}), nil
+			},
+			cfg:        &ScanConfig{SearchValue: "abc", Keys: []string{"user"}, IgnoreCase: true},
+			containers: []string{"svc"},
+			want:       1,
+		},
+		{
+			name: "multi container with limit",
+			logsFn: func(container string, follow bool, since string) (io.ReadCloser, error) {
+				return dockerLogs([]string{"2024-03-10T12:00:00Z id=123", "2024-03-10T12:00:00Z id=123"}), nil
+			},
+			cfg:        &ScanConfig{SearchValue: "123", Keys: []string{"id"}, Limit: 2},
+			containers: []string{"a", "b"},
+			want:       2,
+		},
+		{
+			name: "skips container errors",
+			logsFn: func(container string, follow bool, since string) (io.ReadCloser, error) {
+				if container == "bad" {
+					return nil, fmt.Errorf("docker error")
+				}
+				return dockerLogs([]string{"2024-03-10T12:00:00Z id=123"}), nil
+			},
+			cfg:        &ScanConfig{SearchValue: "123", Keys: []string{"id"}},
+			containers: []string{"good", "bad"},
+			want:       1,
+		},
+		{
+			name: "logs error output",
+			logsFn: func(container string, follow bool, since string) (io.ReadCloser, error) {
+				return nil, fmt.Errorf("docker scan error")
+			},
+			cfg:        &ScanConfig{SearchValue: "123", Keys: []string{"user"}},
+			containers: []string{"auth"},
+			want:       0,
+			wantErrLog: "docker scan error",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mock := &mockDockerClient{
+				logsFn: tt.logsFn,
+				listFn: func() ([]string, error) { return tt.containers, nil },
+			}
+
+			lp := NewLineProcessor(tt.cfg, parser.TextParser{})
+			var out, errOut bytes.Buffer
+			ds := NewDockerScanner(lp, mock, &out, &errOut)
+
+			results := ds.Scan(tt.containers)
+
+			if len(results) != tt.want {
+				fmt.Println(results)
+				t.Errorf("expected %d results, got %d", tt.want, len(results))
+			}
+
+			if tt.wantErrLog != "" && !strings.Contains(errOut.String(), tt.wantErrLog) {
+				t.Errorf("expected error log containing %q, got %q", tt.wantErrLog, errOut.String())
+			}
+		})
+	}
+}
+
+func TestDockerScanner_Scan_JSON(t *testing.T) {
+	tests := []struct {
+		name        string
+		container   string
+		logLines    []string
+		expectedLen int
+		assert      func(t *testing.T, results []domain.LogEntry)
+	}{
+		{
+			name:      "valid json logs",
+			container: "auth",
+			logLines: []string{
+				`{"time":"2024-03-10T12:00:00Z","user":"123","status":"ok"}`,
+				`{"time":"2024-03-10T12:00:00Z","user":"456","status":"fail"}`,
+				`{"time":"2024-03-10T12:00:00Z","user":"123","status":"ok"}`,
+			},
+			expectedLen: 2,
+			assert: func(t *testing.T, results []domain.LogEntry) {
+				for _, r := range results {
+					if r.Service != "auth" {
+						t.Errorf("expected service auth, got %s", r.Service)
+					}
+				}
+			},
+		},
+		{
+			name:      "invalid json lines are skipped",
+			container: "svc",
+			logLines: []string{
+				`{"time":"2024-03-10T12:00:00Z","user":"123"}`,
+				`invalid json`,
+				`{"time":"2024-03-10T12:00:00Z","user":"123"}`,
+			},
+			expectedLen: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mock := &mockDockerClient{
+				logsFn: func(container string, follow bool, since string) (io.ReadCloser, error) {
+					return dockerLogs(tt.logLines), nil
+				},
+			}
+
+			cfg := &ScanConfig{
+				SearchValue: "123",
+				Keys:        []string{"user"},
+			}
+
+			ds := newTestDockerScanner(cfg, parser.JSONParser{}, mock)
+
+			results := ds.Scan([]string{tt.container})
+
+			if len(results) != tt.expectedLen {
+				t.Fatalf("expected %d results, got %d", tt.expectedLen, len(results))
+			}
+
+			if tt.assert != nil {
+				tt.assert(t, results)
+			}
+		})
+	}
+}
+
+func TestDockerScanner_ListSources(t *testing.T) {
+	tests := []struct {
+		name       string
+		containers []string
+		services   []string
+		want       []string
+	}{
+		{
+			name:       "no filter",
+			containers: []string{"auth", "db"},
+			services:   []string{},
+			want:       []string{"auth", "db"},
+		},
+		{
+			name:       "exact match",
+			containers: []string{"auth", "db"},
+			services:   []string{"auth", " "}, //skip empty strings
+			want:       []string{"auth"},
+		},
+		{
+			name:       "wildcard",
+			containers: []string{"svc", "svc-1", "db"},
+			services:   []string{"svc*"},
+			want:       []string{"svc", "svc-1"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mock := &mockDockerClient{
+				listFn: func() ([]string, error) {
+					return tt.containers, nil
+				},
+			}
+
+			cfg := &ScanConfig{
+				Services: tt.services,
+			}
+
+			ds := newTestDockerScanner(cfg, mockParser{}, mock)
+
+			got, err := ds.ListSources()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			sort.Strings(got)
+			sort.Strings(tt.want)
+
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("expected %v, got %v", tt.want, got)
+			}
+		})
+	}
+}
+
+func TestDockerScanner_Follow(t *testing.T) {
+	cfg := &ScanConfig{
+		SearchValue: "123",
+		Keys:        []string{"user"},
+	}
+	lp := NewLineProcessor(cfg, parser.TextParser{})
+
+	tests := []struct {
+		name       string
+		clientLogs func(container string, follow bool, since string) (io.ReadCloser, error)
+		clientList func() ([]string, error)
+		containers []string
+		want       []string
+	}{
+		{
+			name: "single container logs",
+			clientLogs: func(container string, follow bool, since string) (io.ReadCloser, error) {
+				return io.NopCloser(strings.NewReader("2024-03-10T12:00:00Z user=123 status=ok")), nil
+			},
+			clientList: func() ([]string, error) { return []string{"auth"}, nil },
+			containers: []string{"auth"},
+			want:       []string{"2024-03-10T12:00:00Z [auth] user=123 status=ok"},
+		},
+		{
+			name: "multiple containers",
+			clientLogs: func(container string, follow bool, since string) (io.ReadCloser, error) {
+				if container == "auth" {
+					return io.NopCloser(strings.NewReader("2024-03-10T12:00:00Z user=123")), nil
+				}
+				return io.NopCloser(strings.NewReader("2024-03-10T12:00:00Z user=123")), nil
+			},
+			clientList: func() ([]string, error) { return []string{"auth", "db"}, nil },
+			containers: []string{"auth", "db"},
+			want:       []string{"2024-03-10T12:00:00Z [auth] user=123", "2024-03-10T12:00:00Z [db] user=123"},
+		},
+		{
+			name: "ignore lines that don't match search",
+			clientLogs: func(container string, follow bool, since string) (io.ReadCloser, error) {
+				return io.NopCloser(strings.NewReader("2024-03-10T12:00:00Z user=123\n2024-03-10T12:00:00Z other=xyz")), nil
+			},
+			clientList: func() ([]string, error) { return []string{"svc"}, nil },
+			containers: []string{"svc"},
+			want:       []string{"2024-03-10T12:00:00Z [svc] user=123"},
+		},
+		{
+			name: "container returns error",
+			clientLogs: func(container string, follow bool, since string) (io.ReadCloser, error) {
+				return nil, errTest
+			},
+			clientList: func() ([]string, error) { return []string{"auth"}, nil },
+			containers: []string{"auth"},
+			want:       []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := &mockDockerClient{
+				logsFn: tt.clientLogs,
+				listFn: tt.clientList,
+			}
+
+			var out bytes.Buffer
+			ds := NewDockerScanner(lp, client, &out, io.Discard)
+
+			ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+			defer cancel()
+
+			ds.Follow(ctx, tt.containers, &mockFormatter{})
+
+			lines := strings.FieldsFunc(out.String(), func(r rune) bool { return r == '\n' || r == '\r' })
+
+			sort.Strings(lines)
+			want := append([]string(nil), tt.want...)
+			sort.Strings(want)
+
+			if len(lines) != len(want) {
+				t.Fatalf("expected %v lines, got %v", len(want), len(lines))
+			}
+			for i := range lines {
+				if lines[i] != want[i] {
+					t.Errorf("line %d: expected %q, got %q", i, want[i], lines[i])
+				}
+			}
+		})
+	}
+}
+
+func TestDockerScanner_Follow_Errors(t *testing.T) {
+	cfg := &ScanConfig{
+		SearchValue: "123",
+		Keys:        []string{"user"},
+	}
+	lp := NewLineProcessor(cfg, mockParser{})
+
+	client := &mockDockerClient{
+		logsFn: func(container string, follow bool, since string) (io.ReadCloser, error) {
+			return nil, fmt.Errorf("docker error for %s", container)
+		},
+		listFn: func() ([]string, error) { return []string{"auth"}, nil },
+	}
+
+	var out bytes.Buffer
+	var errOut bytes.Buffer
+
+	ds := NewDockerScanner(lp, client, &out, &errOut)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	ds.Follow(ctx, []string{"auth"}, &mockFormatter{})
+
+	if !strings.Contains(errOut.String(), "docker error for auth") {
+		t.Errorf("expected error log, got %q", errOut.String())
+	}
+}

--- a/internal/scanner/factory.go
+++ b/internal/scanner/factory.go
@@ -2,6 +2,8 @@ package scanner
 
 import (
 	"fmt"
+	"os"
+	"time"
 
 	"github.com/sagarmaheshwary/reqlog/internal/docker"
 )
@@ -9,9 +11,9 @@ import (
 func New(source string, lp *LineProcessor) (Scanner, error) {
 	switch source {
 	case "file":
-		return NewFileScanner(lp), nil
+		return NewFileScanner(lp, time.Second, os.Stdout, os.Stderr), nil
 	case "docker":
-		return NewDockerScanner(lp, docker.NewCLIDockerClient()), nil
+		return NewDockerScanner(lp, docker.NewDockerCLIClient(), os.Stdout, os.Stderr), nil
 	default:
 		return nil, fmt.Errorf("unknown source type")
 	}

--- a/internal/scanner/factory.go
+++ b/internal/scanner/factory.go
@@ -1,13 +1,17 @@
 package scanner
 
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/sagarmaheshwary/reqlog/internal/docker"
+)
 
 func New(source string, lp *LineProcessor) (Scanner, error) {
 	switch source {
 	case "file":
 		return NewFileScanner(lp), nil
 	case "docker":
-		return NewDockerScanner(lp), nil
+		return NewDockerScanner(lp, docker.NewCLIDockerClient()), nil
 	default:
 		return nil, fmt.Errorf("unknown source type")
 	}

--- a/internal/scanner/factory.go
+++ b/internal/scanner/factory.go
@@ -1,0 +1,14 @@
+package scanner
+
+import "fmt"
+
+func New(source string, lp *LineProcessor) (Scanner, error) {
+	switch source {
+	case "file":
+		return NewFileScanner(lp), nil
+	case "docker":
+		return NewDockerScanner(lp), nil
+	default:
+		return nil, fmt.Errorf("unknown source type")
+	}
+}

--- a/internal/scanner/factory_test.go
+++ b/internal/scanner/factory_test.go
@@ -1,0 +1,64 @@
+package scanner
+
+import "testing"
+
+func TestNewScanner(t *testing.T) {
+	cfg := &ScanConfig{}
+	lp := NewLineProcessor(cfg, mockParser{})
+
+	tests := []struct {
+		name    string
+		source  string
+		wantErr bool
+		check   func(t *testing.T, s Scanner)
+	}{
+		{
+			name:   "file source",
+			source: "file",
+			check: func(t *testing.T, s Scanner) {
+				if _, ok := s.(*FileScanner); !ok {
+					t.Fatalf("expected *FileScanner")
+				}
+			},
+		},
+		{
+			name:   "docker source",
+			source: "docker",
+			check: func(t *testing.T, s Scanner) {
+				if _, ok := s.(*DockerScanner); !ok {
+					t.Fatalf("expected *DockerScanner")
+				}
+			},
+		},
+		{
+			name:    "unknown source",
+			source:  "unknown",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s, err := New(tt.source, lp)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if s == nil {
+				t.Fatalf("expected scanner, got nil")
+			}
+
+			if tt.check != nil {
+				tt.check(t, s)
+			}
+		})
+	}
+}

--- a/internal/scanner/file_scanner.go
+++ b/internal/scanner/file_scanner.go
@@ -3,6 +3,7 @@ package scanner
 import (
 	"bufio"
 	"container/heap"
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -26,14 +27,25 @@ type ScanConfig struct {
 }
 
 type FileScanner struct {
-	offsets       map[string]int64
-	lineProcessor *LineProcessor
+	offsets        map[string]int64
+	lineProcessor  *LineProcessor
+	followInterval time.Duration
+	out            io.Writer
+	errOut         io.Writer
 }
 
-func NewFileScanner(lp *LineProcessor) *FileScanner {
+func NewFileScanner(
+	lp *LineProcessor,
+	followInterval time.Duration,
+	out io.Writer,
+	errOut io.Writer,
+) *FileScanner {
 	return &FileScanner{
-		offsets:       make(map[string]int64),
-		lineProcessor: lp,
+		offsets:        make(map[string]int64),
+		lineProcessor:  lp,
+		followInterval: followInterval, // default
+		out:            out,
+		errOut:         errOut,
 	}
 }
 
@@ -50,7 +62,7 @@ func (fs *FileScanner) Scan(files []string) []domain.LogEntry {
 	for _, path := range files {
 		file, err := os.Open(path)
 		if err != nil {
-			logScanError(path, err)
+			logScanError(fs.errOut, path, err)
 			continue
 		}
 
@@ -85,7 +97,7 @@ func (fs *FileScanner) Scan(files []string) []domain.LogEntry {
 		}()
 
 		if err != nil {
-			logScanError(path, err)
+			logScanError(fs.errOut, path, err)
 		}
 
 		fs.offsets[path] = offset
@@ -98,63 +110,65 @@ func (fs *FileScanner) Scan(files []string) []domain.LogEntry {
 	return results
 }
 
-func (fs *FileScanner) Follow(files []string) {
-	f := formatter.NewFormatter([]domain.LogEntry{})
+func (fs *FileScanner) Follow(ctx context.Context, files []string, f formatter.LogFormatter) {
+	ticker := time.NewTicker(fs.followInterval)
+	defer ticker.Stop()
 
 	for {
-		for _, path := range files {
-			file, err := os.Open(path)
-			if err != nil {
-				logScanError(path, err)
-				continue
+		select {
+		case <-ctx.Done():
+			return
+
+		case <-ticker.C:
+			for _, path := range files {
+				fs.processFile(path, f)
 			}
+		}
+	}
+}
 
-			offset, err := func() (int64, error) {
-				defer file.Close()
+func (fs *FileScanner) processFile(path string, f formatter.LogFormatter) {
+	file, err := os.Open(path)
+	if err != nil {
+		logScanError(fs.errOut, path, err)
+		return
+	}
+	defer file.Close()
 
-				service := strings.TrimSuffix(filepath.Base(path), ".log")
+	service := strings.TrimSuffix(filepath.Base(path), ".log")
 
-				offset := fs.offsets[path]
-				_, err := file.Seek(offset, io.SeekStart)
-				if err != nil {
-					return 0, err
-				}
+	offset := fs.offsets[path]
 
-				reader := bufio.NewReader(file)
+	_, err = file.Seek(offset, io.SeekStart)
+	if err != nil {
+		logScanError(fs.errOut, path, err)
+		return
+	}
 
-				for {
-					line, err := reader.ReadString('\n')
-					if len(line) > 0 {
-						offset += int64(len(line))
+	reader := bufio.NewReader(file)
 
-						entry, ok := fs.lineProcessor.ProcessLine(line, service)
-						if !ok {
-							continue
-						}
+	for {
+		line, err := reader.ReadString('\n')
 
-						fmt.Println(f.Format(*entry))
-					}
+		if len(line) > 0 {
+			offset += int64(len(line))
 
-					if err != nil {
-						if err == io.EOF {
-							break
-						}
-						return 0, err
-					}
-				}
-
-				return offset, nil
-			}()
-
-			if err != nil {
-				logScanError(path, err)
+			entry, ok := fs.lineProcessor.ProcessLine(line, service)
+			if ok {
+				fmt.Fprintln(fs.out, f.Format(*entry))
 			}
-
-			fs.offsets[path] = offset
 		}
 
-		time.Sleep(1 * time.Second)
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			logScanError(fs.errOut, path, err)
+			return
+		}
 	}
+
+	fs.offsets[path] = offset
 }
 
 func (fs *FileScanner) ListSources() ([]string, error) {
@@ -199,7 +213,7 @@ func (fs *FileScanner) ListSources() ([]string, error) {
 
 		err := filepath.WalkDir(cfg.Dir, func(path string, d os.DirEntry, err error) error {
 			if err != nil {
-				logScanError(path, err)
+				logScanError(fs.errOut, path, err)
 				return nil // continue walking
 			}
 

--- a/internal/scanner/file_scanner.go
+++ b/internal/scanner/file_scanner.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/sagarmaheshwary/reqlog/internal/domain"
 	"github.com/sagarmaheshwary/reqlog/internal/formatter"
-	"github.com/sagarmaheshwary/reqlog/internal/parser"
 )
 
 type ScanConfig struct {
@@ -27,25 +26,24 @@ type ScanConfig struct {
 }
 
 type FileScanner struct {
-	parser  parser.LogParser
-	offsets map[string]int64
-	config  ScanConfig
+	offsets       map[string]int64
+	lineProcessor *LineProcessor
 }
 
-func NewFileScanner(cfg ScanConfig, p parser.LogParser) *FileScanner {
+func NewFileScanner(lp *LineProcessor) *FileScanner {
 	return &FileScanner{
-		parser:  p,
-		offsets: make(map[string]int64),
-		config:  cfg,
+		offsets:       make(map[string]int64),
+		lineProcessor: lp,
 	}
 }
 
 func (fs *FileScanner) Scan(files []string) []domain.LogEntry {
 	var h entryHeap
 	var results []domain.LogEntry
-	sinceTime := parseSince(fs.config.Since)
+	cfg := fs.lineProcessor.config
+	sinceTime := parseSince(cfg.Since)
 
-	if fs.config.Limit > 0 {
+	if cfg.Limit > 0 {
 		heap.Init(&h)
 	}
 
@@ -69,9 +67,9 @@ func (fs *FileScanner) Scan(files []string) []domain.LogEntry {
 				if len(line) > 0 {
 					offset += int64(len(line))
 
-					entry, ok := fs.processLine(line, service)
+					entry, ok := fs.lineProcessor.ProcessLine(line, service)
 					if ok && passesSince(entry, sinceTime) {
-						fs.addEntry(*entry, &results, &h)
+						fs.lineProcessor.AddEntry(*entry, &results, &h)
 					}
 				}
 
@@ -93,7 +91,7 @@ func (fs *FileScanner) Scan(files []string) []domain.LogEntry {
 		fs.offsets[path] = offset
 	}
 
-	if fs.config.Limit > 0 {
+	if cfg.Limit > 0 {
 		results = make([]domain.LogEntry, 0, h.Len())
 		for h.Len() > 0 {
 			results = append(results, heap.Pop(&h).(domain.LogEntry))
@@ -132,7 +130,7 @@ func (fs *FileScanner) Follow(files []string) {
 					if len(line) > 0 {
 						offset += int64(len(line))
 
-						entry, ok := fs.processLine(line, service)
+						entry, ok := fs.lineProcessor.ProcessLine(line, service)
 						if !ok {
 							continue
 						}
@@ -162,18 +160,19 @@ func (fs *FileScanner) Follow(files []string) {
 	}
 }
 
-func (fs *FileScanner) ListLogFiles() ([]string, error) {
+func (fs *FileScanner) ListSources() ([]string, error) {
+	cfg := fs.lineProcessor.config
 	exact := map[string]struct{}{}
 	prefixes := []string{}
 
-	for _, s := range fs.config.Services {
+	for _, s := range cfg.Services {
 		s = strings.TrimSpace(s)
 		if s == "" {
 			continue
 		}
 
 		if strings.HasSuffix(s, "*") {
-			prefixes = append(prefixes, strings.TrimRight(s, "*"))
+			prefixes = append(prefixes, strings.TrimSuffix(s, "*"))
 		} else {
 			exact[s] = struct{}{}
 		}
@@ -198,15 +197,20 @@ func (fs *FileScanner) ListLogFiles() ([]string, error) {
 		return false
 	}
 
-	if fs.config.Recursive {
+	if cfg.Recursive {
 		files := make([]string, 0, 16)
 
-		err := filepath.Walk(fs.config.Dir, func(path string, info os.FileInfo, err error) error {
-			if err != nil || info == nil || info.IsDir() {
+		err := filepath.WalkDir(cfg.Dir, func(path string, d os.DirEntry, err error) error {
+			if err != nil {
+				logFileScanError(path, err)
+				return nil // continue walking
+			}
+
+			if d.IsDir() {
 				return nil
 			}
 
-			name := info.Name()
+			name := d.Name()
 
 			if !strings.HasSuffix(name, ".log") {
 				return nil
@@ -222,7 +226,7 @@ func (fs *FileScanner) ListLogFiles() ([]string, error) {
 		return files, err
 	}
 
-	entries, err := os.ReadDir(fs.config.Dir)
+	entries, err := os.ReadDir(cfg.Dir)
 	if err != nil {
 		return nil, err
 	}
@@ -244,125 +248,8 @@ func (fs *FileScanner) ListLogFiles() ([]string, error) {
 			continue
 		}
 
-		files = append(files, filepath.Join(fs.config.Dir, name))
+		files = append(files, filepath.Join(cfg.Dir, name))
 	}
 
 	return files, nil
-}
-
-func (fs *FileScanner) processLine(line, service string) (*domain.LogEntry, bool) {
-	// fast pre-filter
-	if fs.config.IgnoreCase {
-		if !containsFoldASCII(line, fs.config.SearchValue) {
-			return nil, false
-		}
-	} else {
-		if !strings.Contains(line, fs.config.SearchValue) {
-			return nil, false
-		}
-	}
-
-	line = strings.TrimRight(line, "\r\n")
-
-	foundID, ok := fs.parser.ExtractField(line, fs.config.Keys)
-	if !ok || !match(foundID, fs.config.SearchValue, fs.config.IgnoreCase) {
-		return nil, false
-	}
-
-	entry, err := fs.parser.Parse(line, service)
-	if err != nil {
-		return nil, false
-	}
-
-	return &entry, true
-}
-
-func (fs *FileScanner) addEntry(
-	entry domain.LogEntry,
-	results *[]domain.LogEntry,
-	h *entryHeap,
-) {
-	if fs.config.Limit <= 0 {
-		*results = append(*results, entry)
-		return
-	}
-
-	if h.Len() < fs.config.Limit {
-		heap.Push(h, entry)
-		return
-	}
-
-	if entry.Timestamp.After((*h)[0].Timestamp) {
-		heap.Pop(h)
-		heap.Push(h, entry)
-	}
-}
-
-func match(foundID, SearchValue string, ignoreCase bool) bool {
-	if ignoreCase {
-		return strings.EqualFold(foundID, SearchValue)
-	}
-	return foundID == SearchValue
-}
-
-func passesSince(entry *domain.LogEntry, sinceTime time.Time) bool {
-	if sinceTime.IsZero() {
-		return true
-	}
-	return !entry.Timestamp.Before(sinceTime)
-}
-
-func parseSince(s string) time.Time {
-	if s == "" {
-		return time.Time{}
-	}
-
-	d, err := time.ParseDuration(s)
-	if err != nil {
-		return time.Time{}
-	}
-
-	return time.Now().Add(-d)
-}
-
-func asciiLower(b byte) byte {
-	if b >= 'A' && b <= 'Z' {
-		return b + ('a' - 'A')
-	}
-	return b
-}
-
-func containsFoldASCII(s, substr string) bool {
-	n := len(substr)
-	if n == 0 {
-		return true
-	}
-	if n > len(s) {
-		return false
-	}
-
-	first := asciiLower(substr[0])
-
-	for i := 0; i <= len(s)-n; i++ {
-		if asciiLower(s[i]) != first {
-			continue
-		}
-
-		ok := true
-		for j := 1; j < n; j++ {
-			if asciiLower(s[i+j]) != asciiLower(substr[j]) {
-				ok = false
-				break
-			}
-		}
-		if ok {
-			return true
-		}
-	}
-
-	return false
-}
-
-func logFileScanError(path string, err error) {
-	fmt.Fprintf(os.Stderr, "error scanning %s: %v\n", path, err)
 }

--- a/internal/scanner/file_scanner.go
+++ b/internal/scanner/file_scanner.go
@@ -50,7 +50,7 @@ func (fs *FileScanner) Scan(files []string) []domain.LogEntry {
 	for _, path := range files {
 		file, err := os.Open(path)
 		if err != nil {
-			logFileScanError(path, err)
+			logScanError(path, err)
 			continue
 		}
 
@@ -85,17 +85,14 @@ func (fs *FileScanner) Scan(files []string) []domain.LogEntry {
 		}()
 
 		if err != nil {
-			logFileScanError(path, err)
+			logScanError(path, err)
 		}
 
 		fs.offsets[path] = offset
 	}
 
 	if cfg.Limit > 0 {
-		results = make([]domain.LogEntry, 0, h.Len())
-		for h.Len() > 0 {
-			results = append(results, heap.Pop(&h).(domain.LogEntry))
-		}
+		results = drainHeap(&h)
 	}
 
 	return results
@@ -108,7 +105,7 @@ func (fs *FileScanner) Follow(files []string) {
 		for _, path := range files {
 			file, err := os.Open(path)
 			if err != nil {
-				logFileScanError(path, err)
+				logScanError(path, err)
 				continue
 			}
 
@@ -150,7 +147,7 @@ func (fs *FileScanner) Follow(files []string) {
 			}()
 
 			if err != nil {
-				logFileScanError(path, err)
+				logScanError(path, err)
 			}
 
 			fs.offsets[path] = offset
@@ -171,8 +168,8 @@ func (fs *FileScanner) ListSources() ([]string, error) {
 			continue
 		}
 
-		if strings.HasSuffix(s, "*") {
-			prefixes = append(prefixes, strings.TrimSuffix(s, "*"))
+		if before, ok := strings.CutSuffix(s, "*"); ok {
+			prefixes = append(prefixes, before)
 		} else {
 			exact[s] = struct{}{}
 		}
@@ -202,7 +199,7 @@ func (fs *FileScanner) ListSources() ([]string, error) {
 
 		err := filepath.WalkDir(cfg.Dir, func(path string, d os.DirEntry, err error) error {
 			if err != nil {
-				logFileScanError(path, err)
+				logScanError(path, err)
 				return nil // continue walking
 			}
 

--- a/internal/scanner/file_scanner_benchmark_test.go
+++ b/internal/scanner/file_scanner_benchmark_test.go
@@ -86,7 +86,7 @@ func BenchmarkScanDir_PlainText(b *testing.B) {
 		}
 		lp := NewLineProcessor(cfg, p)
 
-		fs := NewFileScanner(lp)
+		fs := NewFileScanner(lp, time.Second, os.Stdout, os.Stderr)
 		files, err := fs.ListSources()
 		if err != nil {
 			b.Fatal(err)
@@ -116,7 +116,7 @@ func BenchmarkScanDir_JSON(b *testing.B) {
 		}
 		lp := NewLineProcessor(cfg, p)
 
-		fs := NewFileScanner(lp)
+		fs := NewFileScanner(lp, time.Second, os.Stdout, os.Stderr)
 		files, err := fs.ListSources()
 		if err != nil {
 			b.Fatal(err)

--- a/internal/scanner/file_scanner_benchmark_test.go
+++ b/internal/scanner/file_scanner_benchmark_test.go
@@ -76,16 +76,18 @@ func BenchmarkScanDir_PlainText(b *testing.B) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		p, _ := parser.NewParser(parser.TypeText)
-
-		fs := NewFileScanner(ScanConfig{
+		p, _ := parser.New(parser.TypeText)
+		cfg := &ScanConfig{
 			Dir:         dir,
 			SearchValue: "abc123",
 			IgnoreCase:  false,
 			Keys:        parser.DefaultKeys,
 			Since:       "",
-		}, p)
-		files, err := fs.ListLogFiles()
+		}
+		lp := NewLineProcessor(cfg, p)
+
+		fs := NewFileScanner(lp)
+		files, err := fs.ListSources()
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -104,16 +106,18 @@ func BenchmarkScanDir_JSON(b *testing.B) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		p, _ := parser.NewParser(parser.TypeJSON)
-
-		fs := NewFileScanner(ScanConfig{
+		p, _ := parser.New(parser.TypeJSON)
+		cfg := &ScanConfig{
 			Dir:         dir,
 			SearchValue: "json-abc",
 			IgnoreCase:  false,
 			Keys:        parser.DefaultKeys,
 			Since:       "",
-		}, p)
-		files, err := fs.ListLogFiles()
+		}
+		lp := NewLineProcessor(cfg, p)
+
+		fs := NewFileScanner(lp)
+		files, err := fs.ListSources()
 		if err != nil {
 			b.Fatal(err)
 		}

--- a/internal/scanner/file_scanner_mock_test.go
+++ b/internal/scanner/file_scanner_mock_test.go
@@ -1,26 +1,31 @@
 package scanner
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/sagarmaheshwary/reqlog/internal/domain"
 )
 
 type mockParser struct {
-	extractOK bool
-	parseErr  error
+	extractOK      bool
+	parseErr       bool
+	extractedValue string
 }
 
 func (m mockParser) ExtractField(line string, keys []string) (string, bool) {
 	if !m.extractOK {
 		return "", false
 	}
+	if m.extractedValue != "" {
+		return m.extractedValue, true
+	}
 	return "123", true
 }
 
 func (m mockParser) Parse(line, service string) (domain.LogEntry, error) {
-	if m.parseErr != nil {
-		return domain.LogEntry{}, m.parseErr
+	if m.parseErr {
+		return domain.LogEntry{}, fmt.Errorf("parse error")
 	}
 	return domain.LogEntry{
 		Timestamp: time.Now(),

--- a/internal/scanner/file_scanner_test.go
+++ b/internal/scanner/file_scanner_test.go
@@ -1,16 +1,27 @@
 package scanner
 
 import (
-	"container/heap"
-	"errors"
 	"os"
 	"path/filepath"
+	"reflect"
+	"sort"
 	"testing"
 	"time"
 
-	"github.com/sagarmaheshwary/reqlog/internal/domain"
 	"github.com/sagarmaheshwary/reqlog/internal/parser"
 )
+
+func newTestFileScanner(cfg *ScanConfig, p parser.LogParser) *FileScanner {
+	lp := NewLineProcessor(cfg, p)
+	return NewFileScanner(lp)
+}
+
+func writeFile(t *testing.T, path string, content []byte) {
+	t.Helper()
+	if err := os.WriteFile(path, content, 0644); err != nil {
+		t.Fatalf("failed to write file: %v", err)
+	}
+}
 
 func TestFileScanner_Scan(t *testing.T) {
 	dir := t.TempDir()
@@ -19,22 +30,18 @@ func TestFileScanner_Scan(t *testing.T) {
 2024-03-10T12:01:00Z user=456 status=fail
 2024-03-10T12:02:00Z user=123 status=ok
 `
+	writeFile(t, filepath.Join(dir, "auth.log"), []byte(logContent))
 
-	filePath := filepath.Join(dir, "auth.log")
-	err := os.WriteFile(filePath, []byte(logContent), 0644)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	cfg := ScanConfig{
+	cfg := &ScanConfig{
 		Dir:         dir,
 		SearchValue: "123",
 		IgnoreCase:  false,
 		Keys:        []string{"user"},
 	}
+	lp := NewLineProcessor(cfg, &parser.TextParser{})
+	fs := NewFileScanner(lp)
 
-	fs := NewFileScanner(cfg, parser.TextParser{})
-	files, err := fs.ListLogFiles()
+	files, err := fs.ListSources()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -61,21 +68,18 @@ func TestFileScanner_Scan_WithSince(t *testing.T) {
 
 	logContent := oldTime + " user=123 status=ok\n" +
 		newTime + " user=123 status=ok\n"
+	writeFile(t, filepath.Join(dir, "svc.log"), []byte(logContent))
 
-	filePath := filepath.Join(dir, "svc.log")
-	if err := os.WriteFile(filePath, []byte(logContent), 0644); err != nil {
-		t.Fatal(err)
-	}
-
-	cfg := ScanConfig{
+	cfg := &ScanConfig{
 		Dir:         dir,
 		SearchValue: "123",
 		Keys:        []string{"user"},
 		Since:       "5m", // should only include recent one
 	}
+	lp := NewLineProcessor(cfg, parser.TextParser{})
 
-	fs := NewFileScanner(cfg, parser.TextParser{})
-	files, err := fs.ListLogFiles()
+	fs := NewFileScanner(lp)
+	files, err := fs.ListSources()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -90,21 +94,18 @@ func TestFileScanner_Scan_IgnoreCase(t *testing.T) {
 	dir := t.TempDir()
 
 	logContent := `2024-03-10T12:00:00Z user=ABC status=ok`
+	writeFile(t, filepath.Join(dir, "svc.log"), []byte(logContent))
 
-	filePath := filepath.Join(dir, "svc.log")
-	if err := os.WriteFile(filePath, []byte(logContent), 0644); err != nil {
-		t.Fatal(err)
-	}
-
-	cfg := ScanConfig{
+	cfg := &ScanConfig{
 		Dir:         dir,
 		SearchValue: "abc",
 		Keys:        []string{"user"},
 		IgnoreCase:  true,
 	}
+	lp := NewLineProcessor(cfg, parser.TextParser{})
 
-	fs := NewFileScanner(cfg, parser.TextParser{})
-	files, err := fs.ListLogFiles()
+	fs := NewFileScanner(lp)
+	files, err := fs.ListSources()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -118,17 +119,18 @@ func TestFileScanner_Scan_IgnoreCase(t *testing.T) {
 func TestFileScanner_Scan_IgnoresNonLogFiles(t *testing.T) {
 	dir := t.TempDir()
 
-	_ = os.WriteFile(filepath.Join(dir, "file.txt"), []byte("test"), 0644)
-	_ = os.WriteFile(filepath.Join(dir, "app.log"), []byte("invalid line"), 0644)
+	writeFile(t, filepath.Join(dir, "file.txt"), []byte("test"))
+	writeFile(t, filepath.Join(dir, "app.log"), []byte("invalid line"))
 
-	cfg := ScanConfig{
+	cfg := &ScanConfig{
 		Dir:         dir,
 		SearchValue: "123",
 		Keys:        []string{"user"},
 	}
+	lp := NewLineProcessor(cfg, parser.TextParser{})
 
-	fs := NewFileScanner(cfg, parser.TextParser{})
-	files, err := fs.ListLogFiles()
+	fs := NewFileScanner(lp)
+	files, err := fs.ListSources()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -145,14 +147,15 @@ func TestScan_MultiFile_GlobalLimit(t *testing.T) {
 	file1 := filepath.Join(dir, "a.log")
 	file2 := filepath.Join(dir, "b.log")
 
-	os.WriteFile(file1, []byte("id=123\nid=123\n"), 0644)
-	os.WriteFile(file2, []byte("id=123\nid=123\n"), 0644)
+	writeFile(t, file1, []byte("id=123\nid=123\n"))
+	writeFile(t, file2, []byte("id=123\nid=123\n"))
 
-	fs := NewFileScanner(ScanConfig{
+	cfg := &ScanConfig{
 		SearchValue: "123",
 		Keys:        []string{"id"},
 		Limit:       2,
-	}, mockParser{extractOK: true})
+	}
+	fs := newTestFileScanner(cfg, mockParser{extractOK: true})
 
 	results := fs.Scan([]string{file1, file2})
 
@@ -167,12 +170,13 @@ func TestScan_SkipsFileErrors(t *testing.T) {
 	valid := filepath.Join(dir, "valid.log")
 	invalid := filepath.Join(dir, "missing.log")
 
-	os.WriteFile(valid, []byte("id=123\n"), 0644)
+	writeFile(t, valid, []byte("id=123\n"))
 
-	fs := NewFileScanner(ScanConfig{
+	cfg := &ScanConfig{
 		SearchValue: "123",
 		Keys:        []string{"id"},
-	}, mockParser{extractOK: true})
+	}
+	fs := newTestFileScanner(cfg, mockParser{extractOK: true})
 
 	results := fs.Scan([]string{valid, invalid})
 
@@ -185,12 +189,13 @@ func TestScan_NoTrailingNewline(t *testing.T) {
 	dir := t.TempDir()
 
 	file := filepath.Join(dir, "a.log")
-	os.WriteFile(file, []byte("id=123"), 0644) // no newline
+	writeFile(t, file, []byte("id=123")) // no newline
 
-	fs := NewFileScanner(ScanConfig{
+	cfg := &ScanConfig{
 		SearchValue: "123",
 		Keys:        []string{"id"},
-	}, mockParser{extractOK: true})
+	}
+	fs := newTestFileScanner(cfg, mockParser{extractOK: true})
 
 	results := fs.Scan([]string{file})
 
@@ -199,373 +204,97 @@ func TestScan_NoTrailingNewline(t *testing.T) {
 	}
 }
 
-func TestListLogFiles_FilterByService(t *testing.T) {
-	dir := t.TempDir()
-
-	os.WriteFile(filepath.Join(dir, "auth.log"), []byte(""), 0644)
-	os.WriteFile(filepath.Join(dir, "db.log"), []byte(""), 0644)
-
-	fs := NewFileScanner(ScanConfig{
-		Dir:      dir,
-		Services: []string{"auth"},
-	}, mockParser{})
-
-	files, err := fs.ListLogFiles()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if len(files) != 1 {
-		t.Fatalf("expected 1 file, got %d", len(files))
-	}
-}
-
-func TestListLogFiles_RecursiveService(t *testing.T) {
-	dir := t.TempDir()
-	os.WriteFile(filepath.Join(dir, "svc.log"), []byte(""), 0644)
-	os.WriteFile(filepath.Join(dir, "svc-1.log"), []byte(""), 0644)
-
-	fs := NewFileScanner(ScanConfig{
-		Dir:      dir,
-		Services: []string{"svc*"},
-	}, mockParser{})
-
-	files, err := fs.ListLogFiles()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if len(files) != 2 {
-		t.Fatalf("expected 2 files, got %d", len(files))
-	}
-}
-
-func TestMatch(t *testing.T) {
-	tests := []struct {
-		name       string
-		found      string
-		search     string
-		ignoreCase bool
-		expected   bool
-	}{
-		{"exact match", "abc", "abc", false, true},
-		{"case mismatch", "ABC", "abc", false, false},
-		{"ignore case match", "ABC", "abc", true, true},
-		{"different values", "abc", "xyz", true, false},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := match(tt.found, tt.search, tt.ignoreCase)
-			if result != tt.expected {
-				t.Fatalf("expected %v, got %v", tt.expected, result)
-			}
-		})
-	}
-}
-
-func TestPassesSince(t *testing.T) {
-	now := time.Now()
-
+func TestListSources(t *testing.T) {
 	tests := []struct {
 		name      string
-		entryTime time.Time
-		since     time.Time
-		expected  bool
-	}{
-		{"since zero", now, time.Time{}, true},
-		{"after since", now, now.Add(-1 * time.Minute), true},
-		{"before since", now.Add(-10 * time.Minute), now.Add(-1 * time.Minute), false},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			entry := domain.LogEntry{Timestamp: tt.entryTime}
-			result := passesSince(&entry, tt.since)
-
-			if result != tt.expected {
-				t.Fatalf("expected %v, got %v", tt.expected, result)
-			}
-		})
-	}
-}
-
-func TestParseSince(t *testing.T) {
-	tests := []struct {
-		name   string
-		input  string
-		isZero bool
-	}{
-		{"empty string", "", true},
-		{"invalid duration", "abc", true},
-		{"valid duration", "5m", false},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := parseSince(tt.input)
-
-			if tt.isZero && !result.IsZero() {
-				t.Fatal("expected zero time")
-			}
-
-			if !tt.isZero && result.IsZero() {
-				t.Fatal("expected non-zero time")
-			}
-		})
-	}
-}
-
-func TestAsciiLower(t *testing.T) {
-	tests := []struct {
-		name     string
-		input    byte
-		expected byte
-	}{
-		{"uppercase A", 'A', 'a'},
-		{"uppercase Z", 'Z', 'z'},
-		{"lowercase a", 'a', 'a'},
-		{"lowercase z", 'z', 'z'},
-		{"number", '5', '5'},
-		{"symbol", '#', '#'},
-		{"mixed char", 'M', 'm'},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := asciiLower(tt.input)
-			if result != tt.expected {
-				t.Fatalf("expected %q, got %q", tt.expected, result)
-			}
-		})
-	}
-}
-
-func TestContainsFoldASCII(t *testing.T) {
-	tests := []struct {
-		name     string
-		s        string
-		substr   string
-		expected bool
+		setup     func(dir string)
+		cfg       *ScanConfig
+		wantFiles func(dir string) []string
 	}{
 		{
-			name:     "exact match",
-			s:        "hello world",
-			substr:   "world",
-			expected: true,
+			name: "skip non-log and subdirectories",
+			setup: func(dir string) {
+				writeFile(t, filepath.Join(dir, "auth.log"), []byte(""))
+				writeFile(t, filepath.Join(dir, "non-log-file"), []byte(""))
+
+				os.Mkdir(filepath.Join(dir, "sub-dir"), 0755)
+				writeFile(t, filepath.Join(dir, "sub-dir", "svc.log"), []byte(""))
+			},
+			cfg: &ScanConfig{
+				Services: []string{},
+			},
+			wantFiles: func(dir string) []string {
+				return []string{filepath.Join(dir, "auth.log")}
+			},
 		},
 		{
-			name:     "case insensitive match",
-			s:        "Hello World",
-			substr:   "world",
-			expected: true,
+			name: "recursive skip non-log and include subdir logs",
+			setup: func(dir string) {
+				writeFile(t, filepath.Join(dir, "auth.log"), []byte(""))
+				writeFile(t, filepath.Join(dir, "non-log-file"), []byte(""))
+
+				os.Mkdir(filepath.Join(dir, "sub-dir"), 0755)
+				writeFile(t, filepath.Join(dir, "sub-dir", "svc.log"), []byte(""))
+				writeFile(t, filepath.Join(dir, "sub-dir", "non-log-file"), []byte(""))
+			},
+			cfg: &ScanConfig{
+				Services:  []string{"svc"},
+				Recursive: true,
+			},
+			wantFiles: func(dir string) []string {
+				return []string{filepath.Join(dir, "sub-dir/svc.log")}
+			},
 		},
 		{
-			name:     "case insensitive reverse",
-			s:        "hello world",
-			substr:   "WORLD",
-			expected: true,
+			name: "filter by service",
+			setup: func(dir string) {
+				writeFile(t, filepath.Join(dir, "auth.log"), []byte(""))
+				writeFile(t, filepath.Join(dir, "db.log"), []byte(""))
+			},
+			cfg: &ScanConfig{
+				Services: []string{"auth", " "}, //skip empty strings
+			},
+			wantFiles: func(dir string) []string {
+				return []string{filepath.Join(dir, "auth.log")}
+			},
 		},
 		{
-			name:     "no match",
-			s:        "hello world",
-			substr:   "abc",
-			expected: false,
-		},
-		{
-			name:     "substring at start",
-			s:        "Hello",
-			substr:   "he",
-			expected: true,
-		},
-		{
-			name:     "substring at end",
-			s:        "Hello",
-			substr:   "LO",
-			expected: true,
-		},
-		{
-			name:     "full string match",
-			s:        "Hello",
-			substr:   "hello",
-			expected: true,
-		},
-		{
-			name:     "empty substring",
-			s:        "hello",
-			substr:   "",
-			expected: true,
-		},
-		{
-			name:     "substring longer than string",
-			s:        "hi",
-			substr:   "hello",
-			expected: false,
-		},
-		{
-			name:     "single character match",
-			s:        "abc",
-			substr:   "B",
-			expected: true,
-		},
-		{
-			name:     "single character no match",
-			s:        "abc",
-			substr:   "D",
-			expected: false,
-		},
-		{
-			name:     "repeated pattern",
-			s:        "aaaAAA",
-			substr:   "AaA",
-			expected: true,
-		},
-		{
-			name:     "special characters unchanged",
-			s:        "hello-world",
-			substr:   "WORLD",
-			expected: true,
-		},
-		{
-			name:     "numbers",
-			s:        "abc123",
-			substr:   "123",
-			expected: true,
-		},
-		{
-			name:     "partial overlap no match",
-			s:        "abc",
-			substr:   "ac",
-			expected: false,
+			name: "wildcard service",
+			setup: func(dir string) {
+				writeFile(t, filepath.Join(dir, "svc.log"), []byte(""))
+				writeFile(t, filepath.Join(dir, "svc-1.log"), []byte(""))
+			},
+			cfg: &ScanConfig{
+				Services:  []string{"svc*"},
+				Recursive: true,
+			},
+			wantFiles: func(dir string) []string {
+				return []string{filepath.Join(dir, "svc.log"), filepath.Join(dir, "svc-1.log")}
+			},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := containsFoldASCII(tt.s, tt.substr)
-			if result != tt.expected {
-				t.Fatalf("expected %v, got %v", tt.expected, result)
-			}
-		})
-	}
-}
+			dir := t.TempDir()
 
-func TestProcessLine(t *testing.T) {
-	tests := []struct {
-		name        string
-		line        string
-		search      string
-		ignoreCase  bool
-		extractOK   bool
-		parseErr    error
-		expectMatch bool
-	}{
-		{
-			name:        "match success",
-			line:        "id=123 hello",
-			search:      "123",
-			extractOK:   true,
-			expectMatch: true,
-		},
-		{
-			name:        "no contains match",
-			line:        "hello world",
-			search:      "123",
-			extractOK:   true,
-			expectMatch: false,
-		},
-		{
-			name:        "extract fails",
-			line:        "id=123",
-			search:      "123",
-			extractOK:   false,
-			expectMatch: false,
-		},
-		{
-			name:        "parse fails",
-			line:        "id=123",
-			search:      "123",
-			extractOK:   true,
-			parseErr:    errors.New("parse error"),
-			expectMatch: false,
-		},
-		{
-			name:        "ignore case match",
-			line:        "ID=123",
-			search:      "123",
-			ignoreCase:  true,
-			extractOK:   true,
-			expectMatch: true,
-		},
-	}
+			tt.setup(dir)
+			tt.cfg.Dir = dir
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			fs := NewFileScanner(ScanConfig{
-				SearchValue: tt.search,
-				IgnoreCase:  tt.ignoreCase,
-				Keys:        []string{"id"},
-			}, mockParser{
-				extractOK: tt.extractOK,
-				parseErr:  tt.parseErr,
-			})
+			fs := newTestFileScanner(tt.cfg, mockParser{})
 
-			_, ok := fs.processLine(tt.line, "svc")
-
-			if ok != tt.expectMatch {
-				t.Fatalf("expected %v, got %v", tt.expectMatch, ok)
-			}
-		})
-	}
-}
-func TestAddEntry(t *testing.T) {
-	now := time.Now()
-
-	tests := []struct {
-		name     string
-		limit    int
-		input    []time.Duration
-		expected int
-	}{
-		{
-			name:     "no limit",
-			limit:    0,
-			input:    []time.Duration{1, 2, 3},
-			expected: 3,
-		},
-		{
-			name:     "limit enforced",
-			limit:    2,
-			input:    []time.Duration{1, 2, 3},
-			expected: 2,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			fs := NewFileScanner(ScanConfig{Limit: tt.limit}, mockParser{})
-			var results []domain.LogEntry
-			var h entryHeap
-
-			if tt.limit > 0 {
-				heap.Init(&h)
+			files, err := fs.ListSources()
+			if err != nil {
+				t.Fatal(err)
 			}
 
-			for _, d := range tt.input {
-				entry := domain.LogEntry{
-					Timestamp: now.Add(d * time.Minute),
-				}
-				fs.addEntry(entry, &results, &h)
-			}
+			wantFiles := tt.wantFiles(dir)
 
-			if tt.limit <= 0 {
-				if len(results) != tt.expected {
-					t.Fatalf("expected %d results, got %d", tt.expected, len(results))
-				}
-			} else {
-				if h.Len() != tt.expected {
-					t.Fatalf("expected heap size %d, got %d", tt.expected, h.Len())
-				}
+			sort.Strings(files)
+			sort.Strings(wantFiles)
+
+			if !reflect.DeepEqual(files, wantFiles) {
+				t.Fatalf("expected %v, got %v", wantFiles, files)
 			}
 		})
 	}

--- a/internal/scanner/file_scanner_test.go
+++ b/internal/scanner/file_scanner_test.go
@@ -1,10 +1,14 @@
 package scanner
 
 import (
+	"bytes"
+	"context"
+	"io"
 	"os"
 	"path/filepath"
 	"reflect"
 	"sort"
+	"strings"
 	"testing"
 	"time"
 
@@ -13,7 +17,7 @@ import (
 
 func newTestFileScanner(cfg *ScanConfig, p parser.LogParser) *FileScanner {
 	lp := NewLineProcessor(cfg, p)
-	return NewFileScanner(lp)
+	return NewFileScanner(lp, time.Second, io.Discard, io.Discard)
 }
 
 func writeFile(t *testing.T, path string, content []byte) {
@@ -39,7 +43,7 @@ func TestFileScanner_Scan(t *testing.T) {
 		Keys:        []string{"user"},
 	}
 	lp := NewLineProcessor(cfg, &parser.TextParser{})
-	fs := NewFileScanner(lp)
+	fs := NewFileScanner(lp, time.Second, io.Discard, io.Discard)
 
 	files, err := fs.ListSources()
 	if err != nil {
@@ -78,7 +82,7 @@ func TestFileScanner_Scan_WithSince(t *testing.T) {
 	}
 	lp := NewLineProcessor(cfg, parser.TextParser{})
 
-	fs := NewFileScanner(lp)
+	fs := NewFileScanner(lp, time.Second, io.Discard, io.Discard)
 	files, err := fs.ListSources()
 	if err != nil {
 		t.Fatal(err)
@@ -104,7 +108,7 @@ func TestFileScanner_Scan_IgnoreCase(t *testing.T) {
 	}
 	lp := NewLineProcessor(cfg, parser.TextParser{})
 
-	fs := NewFileScanner(lp)
+	fs := NewFileScanner(lp, time.Second, io.Discard, io.Discard)
 	files, err := fs.ListSources()
 	if err != nil {
 		t.Fatal(err)
@@ -129,7 +133,7 @@ func TestFileScanner_Scan_IgnoresNonLogFiles(t *testing.T) {
 	}
 	lp := NewLineProcessor(cfg, parser.TextParser{})
 
-	fs := NewFileScanner(lp)
+	fs := NewFileScanner(lp, time.Second, io.Discard, io.Discard)
 	files, err := fs.ListSources()
 	if err != nil {
 		t.Fatal(err)
@@ -147,15 +151,15 @@ func TestScan_MultiFile_GlobalLimit(t *testing.T) {
 	file1 := filepath.Join(dir, "a.log")
 	file2 := filepath.Join(dir, "b.log")
 
-	writeFile(t, file1, []byte("id=123\nid=123\n"))
-	writeFile(t, file2, []byte("id=123\nid=123\n"))
+	writeFile(t, file1, []byte("2024-03-10T12:00:00Z id=123\nid=123\n"))
+	writeFile(t, file2, []byte("2024-03-10T12:00:00Z id=123\nid=123\n"))
 
 	cfg := &ScanConfig{
 		SearchValue: "123",
 		Keys:        []string{"id"},
 		Limit:       2,
 	}
-	fs := newTestFileScanner(cfg, mockParser{extractOK: true})
+	fs := newTestFileScanner(cfg, parser.TextParser{})
 
 	results := fs.Scan([]string{file1, file2})
 
@@ -170,13 +174,13 @@ func TestScan_SkipsFileErrors(t *testing.T) {
 	valid := filepath.Join(dir, "valid.log")
 	invalid := filepath.Join(dir, "missing.log")
 
-	writeFile(t, valid, []byte("id=123\n"))
+	writeFile(t, valid, []byte("2024-03-10T12:00:00Z id=123\n"))
 
 	cfg := &ScanConfig{
 		SearchValue: "123",
 		Keys:        []string{"id"},
 	}
-	fs := newTestFileScanner(cfg, mockParser{extractOK: true})
+	fs := newTestFileScanner(cfg, parser.TextParser{})
 
 	results := fs.Scan([]string{valid, invalid})
 
@@ -189,18 +193,98 @@ func TestScan_NoTrailingNewline(t *testing.T) {
 	dir := t.TempDir()
 
 	file := filepath.Join(dir, "a.log")
-	writeFile(t, file, []byte("id=123")) // no newline
+	writeFile(t, file, []byte("2024-03-10T12:00:00Z id=123")) // no newline
 
 	cfg := &ScanConfig{
 		SearchValue: "123",
 		Keys:        []string{"id"},
 	}
-	fs := newTestFileScanner(cfg, mockParser{extractOK: true})
+	fs := newTestFileScanner(cfg, parser.TextParser{})
 
 	results := fs.Scan([]string{file})
 
 	if len(results) != 1 {
 		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+}
+
+func TestFileScanner_Scan_ErrorLogging(t *testing.T) {
+	cfg := &ScanConfig{
+		SearchValue: "123",
+		Keys:        []string{"user"},
+	}
+	lp := NewLineProcessor(cfg, parser.TextParser{})
+
+	// pass a missing file to trigger error
+	files := []string{"/tmp/nonexistent.log"}
+
+	var out bytes.Buffer
+	var errOut bytes.Buffer
+	fs := NewFileScanner(lp, time.Second, &out, &errOut)
+
+	results := fs.Scan(files)
+
+	if len(results) != 0 {
+		t.Errorf("expected 0 results, got %d", len(results))
+	}
+
+	if !strings.Contains(errOut.String(), "/tmp/nonexistent.log") {
+		t.Errorf("expected error log, got %q", errOut.String())
+	}
+}
+
+func TestFileScanner_Scan_JSON(t *testing.T) {
+	tests := []struct {
+		name        string
+		logLines    []string
+		expectedLen int
+	}{
+		{
+			name: "valid json logs",
+			logLines: []string{
+				`{"time":"2024-03-10T12:00:00Z","user":"123","status":"ok"}`,
+				`{"time":"2024-03-10T12:00:00Z","user":"456","status":"fail"}`,
+			},
+			expectedLen: 1,
+		},
+		{
+			name: "invalid json lines are skipped",
+			logLines: []string{
+				`{"time":"2024-03-10T12:00:00Z","user":"123"}`,
+				`invalid json`,
+				`{"time":"2024-03-10T12:00:00Z","user":"123"}`,
+			},
+			expectedLen: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+
+			content := strings.Join(tt.logLines, "\n")
+			writeFile(t, filepath.Join(dir, "svc.log"), []byte(content))
+
+			cfg := &ScanConfig{
+				Dir:         dir,
+				SearchValue: "123",
+				Keys:        []string{"user"},
+			}
+
+			lp := NewLineProcessor(cfg, parser.JSONParser{})
+			fs := NewFileScanner(lp, time.Second, io.Discard, io.Discard)
+
+			files, err := fs.ListSources()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			results := fs.Scan(files)
+
+			if len(results) != tt.expectedLen {
+				t.Fatalf("expected %d results, got %d", tt.expectedLen, len(results))
+			}
+		})
 	}
 }
 
@@ -297,5 +381,121 @@ func TestListSources(t *testing.T) {
 				t.Fatalf("expected %v, got %v", wantFiles, files)
 			}
 		})
+	}
+}
+
+func TestFileScanner_Follow(t *testing.T) {
+	dir := t.TempDir()
+
+	tests := []struct {
+		name   string
+		files  map[string]string
+		want   []string
+		append func() // optional append after first read
+	}{
+		{
+			name: "single file logs",
+			files: map[string]string{
+				"auth.log": "2024-03-10T12:00:00Z user=123 status=ok\n",
+			},
+			want: []string{"2024-03-10T12:00:00Z [auth] user=123 status=ok"},
+		},
+		{
+			name: "multiple files",
+			files: map[string]string{
+				"auth.log": "2024-03-10T12:00:00Z user=123\n",
+				"db.log":   "2024-03-10T12:00:00Z user=123\n",
+			},
+			want: []string{"2024-03-10T12:00:00Z [auth] user=123", "2024-03-10T12:00:00Z [db] user=123"},
+		},
+		{
+			name: "ignore lines that don't match search",
+			files: map[string]string{
+				"svc.log": "2024-03-10T12:00:00Z user=123\nother=xyz\n",
+			},
+			want: []string{"2024-03-10T12:00:00Z [svc] user=123"},
+		},
+		{
+			name: "new lines appended",
+			files: map[string]string{
+				"append.log": "2024-03-10T12:00:00Z user=123 line1\n",
+			},
+			want: []string{"2024-03-10T12:00:00Z [append] user=123 line1", "2024-03-10T12:00:00Z [append] user=123 line2"},
+			append: func() {
+				fpath := filepath.Join(dir, "append.log")
+				f, _ := os.OpenFile(fpath, os.O_APPEND|os.O_WRONLY, 0644)
+				defer f.Close()
+				f.WriteString("2024-03-10T12:00:00Z user=123 line2\n")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			files := []string{}
+			for fname, content := range tt.files {
+				path := filepath.Join(dir, fname)
+				writeFile(t, path, []byte(content))
+				files = append(files, path)
+			}
+
+			var out bytes.Buffer
+
+			cfg := &ScanConfig{SearchValue: "123", Keys: []string{"user"}}
+			lp := NewLineProcessor(cfg, parser.TextParser{})
+			fs := NewFileScanner(lp, 10*time.Millisecond, &out, io.Discard)
+
+			ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+			defer cancel()
+
+			// Optionally append new lines after start
+			if tt.append != nil {
+				go func() {
+					time.Sleep(100 * time.Millisecond)
+					tt.append()
+				}()
+			}
+
+			fs.Follow(ctx, files, &mockFormatter{})
+
+			lines := strings.FieldsFunc(out.String(), func(r rune) bool { return r == '\n' || r == '\r' })
+
+			sort.Strings(lines)
+			want := append([]string(nil), tt.want...)
+			sort.Strings(want)
+
+			if len(lines) != len(want) {
+				t.Fatalf("expected %v lines, got %v", len(want), len(lines))
+			}
+			for i := range lines {
+				if lines[i] != want[i] {
+					t.Errorf("line %d: expected %q, got %q", i, want[i], lines[i])
+				}
+			}
+		})
+	}
+}
+
+func TestFileScanner_Follow_Errors(t *testing.T) {
+	cfg := &ScanConfig{
+		SearchValue: "123",
+		Keys:        []string{"user"},
+	}
+	lp := NewLineProcessor(cfg, mockParser{extractOK: true})
+
+	var out bytes.Buffer
+	var errOut bytes.Buffer
+	fs := NewFileScanner(lp, 10*time.Millisecond, &out, &errOut)
+
+	// pass a missing file to trigger error
+	files := []string{"/tmp/nonexistent.log"}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	fs.Follow(ctx, files, &mockFormatter{})
+
+	if !strings.Contains(errOut.String(), "error scanning /tmp/nonexistent.log") {
+		t.Errorf("expected error log, got %q", errOut.String())
 	}
 }

--- a/internal/scanner/interface.go
+++ b/internal/scanner/interface.go
@@ -1,9 +1,18 @@
 package scanner
 
-import "github.com/sagarmaheshwary/reqlog/internal/domain"
+import (
+	"io"
+
+	"github.com/sagarmaheshwary/reqlog/internal/domain"
+)
 
 type Scanner interface {
 	Scan(sources []string) []domain.LogEntry
 	Follow(sources []string)
 	ListSources() ([]string, error)
+}
+
+type CLIDockerClient interface {
+	Logs(container string, follow bool, since string) (io.ReadCloser, error)
+	ListContainers() ([]string, error)
 }

--- a/internal/scanner/interface.go
+++ b/internal/scanner/interface.go
@@ -1,0 +1,9 @@
+package scanner
+
+import "github.com/sagarmaheshwary/reqlog/internal/domain"
+
+type Scanner interface {
+	Scan(sources []string) []domain.LogEntry
+	Follow(sources []string)
+	ListSources() ([]string, error)
+}

--- a/internal/scanner/interface.go
+++ b/internal/scanner/interface.go
@@ -1,18 +1,14 @@
 package scanner
 
 import (
-	"io"
+	"context"
 
 	"github.com/sagarmaheshwary/reqlog/internal/domain"
+	"github.com/sagarmaheshwary/reqlog/internal/formatter"
 )
 
 type Scanner interface {
 	Scan(sources []string) []domain.LogEntry
-	Follow(sources []string)
+	Follow(ctx context.Context, sources []string, f formatter.LogFormatter)
 	ListSources() ([]string, error)
-}
-
-type CLIDockerClient interface {
-	Logs(container string, follow bool, since string) (io.ReadCloser, error)
-	ListContainers() ([]string, error)
 }

--- a/internal/scanner/line_processor.go
+++ b/internal/scanner/line_processor.go
@@ -1,0 +1,66 @@
+package scanner
+
+import (
+	"container/heap"
+	"strings"
+
+	"github.com/sagarmaheshwary/reqlog/internal/domain"
+	"github.com/sagarmaheshwary/reqlog/internal/parser"
+)
+
+type LineProcessor struct {
+	config *ScanConfig
+	parser parser.LogParser
+}
+
+func NewLineProcessor(cfg *ScanConfig, p parser.LogParser) *LineProcessor {
+	return &LineProcessor{config: cfg, parser: p}
+}
+
+func (lp *LineProcessor) ProcessLine(line, service string) (*domain.LogEntry, bool) {
+	// fast pre-filter (return if searchValue is not present in the line string)
+	if lp.config.IgnoreCase {
+		if !containsFoldASCII(line, lp.config.SearchValue) {
+			return nil, false
+		}
+	} else {
+		if !strings.Contains(line, lp.config.SearchValue) {
+			return nil, false
+		}
+	}
+
+	line = strings.TrimRight(line, "\r\n")
+
+	foundID, ok := lp.parser.ExtractField(line, lp.config.Keys)
+	if !ok || !match(foundID, lp.config.SearchValue, lp.config.IgnoreCase) {
+		return nil, false
+	}
+
+	entry, err := lp.parser.Parse(line, service)
+	if err != nil {
+		return nil, false
+	}
+
+	return &entry, true
+}
+
+func (lp *LineProcessor) AddEntry(
+	entry domain.LogEntry,
+	results *[]domain.LogEntry,
+	h *entryHeap,
+) {
+	if lp.config.Limit <= 0 {
+		*results = append(*results, entry)
+		return
+	}
+
+	if h.Len() < lp.config.Limit {
+		heap.Push(h, entry)
+		return
+	}
+
+	if entry.Timestamp.After((*h)[0].Timestamp) {
+		heap.Pop(h)
+		heap.Push(h, entry)
+	}
+}

--- a/internal/scanner/line_processor_test.go
+++ b/internal/scanner/line_processor_test.go
@@ -1,0 +1,112 @@
+package scanner
+
+import "testing"
+
+func TestLineProcessor_ProcessLine(t *testing.T) {
+	tests := []struct {
+		name       string
+		line       string
+		search     string
+		ignoreCase bool
+
+		parser mockParser
+		wantOK bool
+	}{
+		{
+			name:       "match normal case",
+			line:       "id=123 status=ok",
+			search:     "123",
+			ignoreCase: false,
+			parser:     mockParser{extractOK: true},
+			wantOK:     true,
+		},
+		{
+			name:       "no match in line (prefilter)",
+			line:       "id=456 status=ok",
+			search:     "123",
+			ignoreCase: false,
+			parser:     mockParser{extractOK: true},
+			wantOK:     false,
+		},
+		{
+			name:       "ignore case match",
+			line:       "ID=ABC status=ok",
+			search:     "abc",
+			ignoreCase: true,
+			parser:     mockParser{extractOK: true, extractedValue: "ABC"},
+			wantOK:     true,
+		},
+		{
+			name:       "ignore case prefilter fail",
+			line:       "id=xyz",
+			search:     "ABC",
+			ignoreCase: true,
+			parser:     mockParser{extractOK: true},
+			wantOK:     false,
+		},
+		{
+			name:       "extract field fails",
+			line:       "id=123",
+			search:     "123",
+			ignoreCase: false,
+			parser:     mockParser{extractOK: false},
+			wantOK:     false,
+		},
+		{
+			name:       "match fails after extract",
+			line:       "id=999",
+			search:     "123",
+			ignoreCase: false,
+			parser: mockParser{
+				extractOK:      true,
+				extractedValue: "999",
+			},
+			wantOK: false,
+		},
+		{
+			name:       "parse fails",
+			line:       "id=123",
+			search:     "123",
+			ignoreCase: false,
+			parser: mockParser{
+				extractOK: true,
+				parseErr:  true,
+			},
+			wantOK: false,
+		},
+		{
+			name:       "trims newline",
+			line:       "id=123\n",
+			search:     "123",
+			ignoreCase: false,
+			parser:     mockParser{extractOK: true},
+			wantOK:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &ScanConfig{
+				SearchValue: tt.search,
+				IgnoreCase:  tt.ignoreCase,
+				Keys:        []string{"id"},
+			}
+
+			lp := NewLineProcessor(cfg, tt.parser)
+
+			entry, ok := lp.ProcessLine(tt.line, "svc")
+
+			if ok != tt.wantOK {
+				t.Fatalf("expected ok=%v, got %v", tt.wantOK, ok)
+			}
+
+			if tt.wantOK && entry == nil {
+				t.Fatal("expected entry, got nil")
+			}
+
+			if !tt.wantOK && entry != nil {
+				t.Fatal("expected nil entry")
+			}
+		})
+	}
+}

--- a/internal/scanner/mocks_test.go
+++ b/internal/scanner/mocks_test.go
@@ -2,10 +2,30 @@ package scanner
 
 import (
 	"fmt"
+	"io"
 	"time"
 
 	"github.com/sagarmaheshwary/reqlog/internal/domain"
 )
+
+type mockDockerClient struct {
+	logsFn func(container string, follow bool, since string) (io.ReadCloser, error)
+	listFn func() ([]string, error)
+}
+
+func (m *mockDockerClient) Logs(container string, follow bool, since string) (io.ReadCloser, error) {
+	return m.logsFn(container, follow, since)
+}
+
+func (m *mockDockerClient) ListContainers() ([]string, error) {
+	return m.listFn()
+}
+
+type mockFormatter struct{}
+
+func (f *mockFormatter) Format(entry domain.LogEntry) string {
+	return entry.Timestamp.Format(time.RFC3339) + " [" + entry.Service + "] " + entry.Message
+}
 
 type mockParser struct {
 	extractOK      bool

--- a/internal/scanner/utils.go
+++ b/internal/scanner/utils.go
@@ -1,0 +1,79 @@
+package scanner
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/sagarmaheshwary/reqlog/internal/domain"
+)
+
+func match(foundID, SearchValue string, ignoreCase bool) bool {
+	if ignoreCase {
+		return strings.EqualFold(foundID, SearchValue)
+	}
+	return foundID == SearchValue
+}
+
+func passesSince(entry *domain.LogEntry, sinceTime time.Time) bool {
+	if sinceTime.IsZero() {
+		return true
+	}
+	return !entry.Timestamp.Before(sinceTime)
+}
+
+func parseSince(s string) time.Time {
+	if s == "" {
+		return time.Time{}
+	}
+
+	d, err := time.ParseDuration(s)
+	if err != nil {
+		return time.Time{}
+	}
+
+	return time.Now().Add(-d)
+}
+
+func asciiLower(b byte) byte {
+	if b >= 'A' && b <= 'Z' {
+		return b + ('a' - 'A')
+	}
+	return b
+}
+
+func containsFoldASCII(s, substr string) bool {
+	n := len(substr)
+	if n == 0 {
+		return true
+	}
+	if n > len(s) {
+		return false
+	}
+
+	first := asciiLower(substr[0])
+
+	for i := 0; i <= len(s)-n; i++ {
+		if asciiLower(s[i]) != first {
+			continue
+		}
+
+		ok := true
+		for j := 1; j < n; j++ {
+			if asciiLower(s[i+j]) != asciiLower(substr[j]) {
+				ok = false
+				break
+			}
+		}
+		if ok {
+			return true
+		}
+	}
+
+	return false
+}
+
+func logFileScanError(path string, err error) {
+	fmt.Fprintf(os.Stderr, "error scanning %s: %v\n", path, err)
+}

--- a/internal/scanner/utils.go
+++ b/internal/scanner/utils.go
@@ -1,6 +1,7 @@
 package scanner
 
 import (
+	"container/heap"
 	"fmt"
 	"os"
 	"strings"
@@ -74,6 +75,14 @@ func containsFoldASCII(s, substr string) bool {
 	return false
 }
 
-func logFileScanError(path string, err error) {
+func logScanError(path string, err error) {
 	fmt.Fprintf(os.Stderr, "error scanning %s: %v\n", path, err)
+}
+
+func drainHeap(h *entryHeap) []domain.LogEntry {
+	out := make([]domain.LogEntry, 0, h.Len())
+	for h.Len() > 0 {
+		out = append(out, heap.Pop(h).(domain.LogEntry))
+	}
+	return out
 }

--- a/internal/scanner/utils.go
+++ b/internal/scanner/utils.go
@@ -3,7 +3,7 @@ package scanner
 import (
 	"container/heap"
 	"fmt"
-	"os"
+	"io"
 	"strings"
 	"time"
 
@@ -75,8 +75,8 @@ func containsFoldASCII(s, substr string) bool {
 	return false
 }
 
-func logScanError(path string, err error) {
-	fmt.Fprintf(os.Stderr, "error scanning %s: %v\n", path, err)
+func logScanError(out io.Writer, path string, err error) {
+	fmt.Fprintf(out, "error scanning %s: %v\n", path, err)
 }
 
 func drainHeap(h *entryHeap) []domain.LogEntry {

--- a/internal/scanner/utils_test.go
+++ b/internal/scanner/utils_test.go
@@ -1,0 +1,218 @@
+package scanner
+
+import (
+	"testing"
+	"time"
+
+	"github.com/sagarmaheshwary/reqlog/internal/domain"
+)
+
+func TestMatch(t *testing.T) {
+	tests := []struct {
+		name       string
+		found      string
+		search     string
+		ignoreCase bool
+		expected   bool
+	}{
+		{"exact match", "abc", "abc", false, true},
+		{"case mismatch", "ABC", "abc", false, false},
+		{"ignore case match", "ABC", "abc", true, true},
+		{"different values", "abc", "xyz", true, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := match(tt.found, tt.search, tt.ignoreCase)
+			if result != tt.expected {
+				t.Fatalf("expected %v, got %v", tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestPassesSince(t *testing.T) {
+	now := time.Now()
+
+	tests := []struct {
+		name      string
+		entryTime time.Time
+		since     time.Time
+		expected  bool
+	}{
+		{"since zero", now, time.Time{}, true},
+		{"after since", now, now.Add(-1 * time.Minute), true},
+		{"before since", now.Add(-10 * time.Minute), now.Add(-1 * time.Minute), false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			entry := domain.LogEntry{Timestamp: tt.entryTime}
+			result := passesSince(&entry, tt.since)
+
+			if result != tt.expected {
+				t.Fatalf("expected %v, got %v", tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestParseSince(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  string
+		isZero bool
+	}{
+		{"empty string", "", true},
+		{"invalid duration", "abc", true},
+		{"valid duration", "5m", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := parseSince(tt.input)
+
+			if tt.isZero && !result.IsZero() {
+				t.Fatal("expected zero time")
+			}
+
+			if !tt.isZero && result.IsZero() {
+				t.Fatal("expected non-zero time")
+			}
+		})
+	}
+}
+
+func TestAsciiLower(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    byte
+		expected byte
+	}{
+		{"uppercase A", 'A', 'a'},
+		{"uppercase Z", 'Z', 'z'},
+		{"lowercase a", 'a', 'a'},
+		{"lowercase z", 'z', 'z'},
+		{"number", '5', '5'},
+		{"symbol", '#', '#'},
+		{"mixed char", 'M', 'm'},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := asciiLower(tt.input)
+			if result != tt.expected {
+				t.Fatalf("expected %q, got %q", tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestContainsFoldASCII(t *testing.T) {
+	tests := []struct {
+		name     string
+		s        string
+		substr   string
+		expected bool
+	}{
+		{
+			name:     "exact match",
+			s:        "hello world",
+			substr:   "world",
+			expected: true,
+		},
+		{
+			name:     "case insensitive match",
+			s:        "Hello World",
+			substr:   "world",
+			expected: true,
+		},
+		{
+			name:     "case insensitive reverse",
+			s:        "hello world",
+			substr:   "WORLD",
+			expected: true,
+		},
+		{
+			name:     "no match",
+			s:        "hello world",
+			substr:   "abc",
+			expected: false,
+		},
+		{
+			name:     "substring at start",
+			s:        "Hello",
+			substr:   "he",
+			expected: true,
+		},
+		{
+			name:     "substring at end",
+			s:        "Hello",
+			substr:   "LO",
+			expected: true,
+		},
+		{
+			name:     "full string match",
+			s:        "Hello",
+			substr:   "hello",
+			expected: true,
+		},
+		{
+			name:     "empty substring",
+			s:        "hello",
+			substr:   "",
+			expected: true,
+		},
+		{
+			name:     "substring longer than string",
+			s:        "hi",
+			substr:   "hello",
+			expected: false,
+		},
+		{
+			name:     "single character match",
+			s:        "abc",
+			substr:   "B",
+			expected: true,
+		},
+		{
+			name:     "single character no match",
+			s:        "abc",
+			substr:   "D",
+			expected: false,
+		},
+		{
+			name:     "repeated pattern",
+			s:        "aaaAAA",
+			substr:   "AaA",
+			expected: true,
+		},
+		{
+			name:     "special characters unchanged",
+			s:        "hello-world",
+			substr:   "WORLD",
+			expected: true,
+		},
+		{
+			name:     "numbers",
+			s:        "abc123",
+			substr:   "123",
+			expected: true,
+		},
+		{
+			name:     "partial overlap no match",
+			s:        "abc",
+			substr:   "ac",
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := containsFoldASCII(tt.s, tt.substr)
+			if result != tt.expected {
+				t.Fatalf("expected %v, got %v", tt.expected, result)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Overview
This PR introduces Docker logs support and refactors the scanner architecture to support multiple log sources (file, docker, etc).
It also improves output formatting and adds comprehensive test coverage across scanner and formatter components.

## Features
-  Docker logs support (scan & follow container logs)
-  Improved log formatting:
  - Colored key fields
  - Better field ordering (message → level → rest)
-  Added `--source` flag (file (default), docker)

## Refactoring
- Introduced Scanner interface for extensible log sources
- Refactored FileScanner and DockerScanner for better separation of concerns
- Extracted line processing logic into `LineProcessor`
- Moved shared helpers to `scanner/utils`
- Refactored parser and scanner factory

## Tests
- Added tests for:
  - Formatter
  - FileScanner (including Follow)
  - DockerScanner
- Refactored common tests to use table-driven approach