### PR TITLE
Enhance --since flag with RFC3339 and date support

### DIFF
--- a/cmd/reqlog/main.go
+++ b/cmd/reqlog/main.go
@@ -23,7 +23,7 @@ var (
 	jsonMode    = flag.Bool("json", false, "parse logs as JSON (one JSON object per line)")
 	follow      = flag.Bool("follow", false, "follow logs in real time (like tail -f)")
 	key         = flag.String("key", "", "field key to match (e.g. request_id, trace_id, event_key)")
-	since       = flag.String("since", "", "only include logs newer than duration (e.g. 5m, 1h)")
+	since       = flag.String("since", "", "filter logs newer than: duration (5m, 1h), RFC3339 timestamp, or YYYY-MM-DD (UTC)")
 	recursive   = flag.Bool("recursive", true, "scan directories recursively")
 	service     = flag.String("service", "", "filter by service name (comma-separated, e.g. order-service,inventory-service)")
 	source      = flag.String("source", "file", `log source backend: "file", "docker"`)

--- a/internal/scanner/docker_scanner.go
+++ b/internal/scanner/docker_scanner.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"log"
 	"strings"
 	"sync"
 
@@ -39,7 +40,10 @@ func (ds *DockerScanner) Scan(containers []string) []domain.LogEntry {
 
 	var h entryHeap
 	var results []domain.LogEntry
-	sinceTime := parseSince(ds.lineProcessor.config.Since)
+	sinceTime, err := parseSince(cfg.Since)
+	if err != nil {
+		log.Fatal(err)
+	}
 
 	if cfg.Limit > 0 {
 		heap.Init(&h)

--- a/internal/scanner/file_scanner.go
+++ b/internal/scanner/file_scanner.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -53,7 +54,10 @@ func (fs *FileScanner) Scan(files []string) []domain.LogEntry {
 	var h entryHeap
 	var results []domain.LogEntry
 	cfg := fs.lineProcessor.config
-	sinceTime := parseSince(cfg.Since)
+	sinceTime, err := parseSince(cfg.Since)
+	if err != nil {
+		log.Fatal(err)
+	}
 
 	if cfg.Limit > 0 {
 		heap.Init(&h)

--- a/internal/scanner/utils.go
+++ b/internal/scanner/utils.go
@@ -24,17 +24,24 @@ func passesSince(entry *domain.LogEntry, sinceTime time.Time) bool {
 	return !entry.Timestamp.Before(sinceTime)
 }
 
-func parseSince(s string) time.Time {
+func parseSince(s string) (time.Time, error) {
 	if s == "" {
-		return time.Time{}
+		return time.Time{}, nil
+	}
+	if d, err := time.ParseDuration(s); err == nil {
+		return time.Now().Add(-d), nil
+	}
+	if t, err := time.Parse(time.RFC3339Nano, s); err == nil {
+		return t, nil
+	}
+	if t, err := time.Parse("2006-01-02", s); err == nil {
+		return t, nil
 	}
 
-	d, err := time.ParseDuration(s)
-	if err != nil {
-		return time.Time{}
-	}
-
-	return time.Now().Add(-d)
+	return time.Time{}, fmt.Errorf(
+		"invalid --since value %q\n\nExamples:\n  --since 10m\n  --since 1h\n  --since 2026-04-29T19:44:06Z\n  --since 2026-04-29",
+		s,
+	)
 }
 
 func asciiLower(b byte) byte {

--- a/internal/scanner/utils_test.go
+++ b/internal/scanner/utils_test.go
@@ -59,25 +59,29 @@ func TestPassesSince(t *testing.T) {
 
 func TestParseSince(t *testing.T) {
 	tests := []struct {
-		name   string
-		input  string
-		isZero bool
+		name      string
+		input     string
+		expectErr bool
 	}{
-		{"empty string", "", true},
-		{"invalid duration", "abc", true},
+		{"empty string", "", false},
+		{"invalid input", "abc", true},
 		{"valid duration", "5m", false},
+		{"valid RFC3339", "2026-04-29T19:44:06Z", false},
+		{"valid date only", "2026-04-29", false},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := parseSince(tt.input)
+			result, err := parseSince(tt.input)
 
-			if tt.isZero && !result.IsZero() {
-				t.Fatal("expected zero time")
+			if tt.expectErr && err == nil {
+				t.Fatal("expected error, got nil")
 			}
-
-			if !tt.isZero && result.IsZero() {
-				t.Fatal("expected non-zero time")
+			if !tt.expectErr && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if err == nil && result.IsZero() && tt.input != "" {
+				t.Fatal("expected non-zero time for valid input")
 			}
 		})
 	}


### PR DESCRIPTION
Extend `--since` flag to support RFC3339 timestamps and date-only format in addition to duration. Invalid inputs now fail fast with clear error messages.

### Supported formats

- **Duration (existing):**

  ```bash
  reqlog --since 10m
  reqlog --since 1h
  ```

- **RFC3339 timestamps (new):**

  ```bash
  reqlog --since 2026-03-20T14:00:00Z
  reqlog --since 2026-03-20T14:00:00.000Z
  ```

- **Date-only (new):**

  ```bash
  reqlog --since 2026-03-20
  ```

  Interpreted as UTC.

---

### Behavior changes

- Strict validation (no silent fallback)
- Invalid inputs exit with clear error
- Backward compatible with duration format

---

### Invalid examples

```bash
reqlog --since abc
reqlog --since 2026/03/20
```
