### PR TITLE
Optimize --limit and add --latest for globally latest results

### DIFF
--- a/cmd/reqlog/main.go
+++ b/cmd/reqlog/main.go
@@ -18,7 +18,8 @@ import (
 var (
 	dir         = flag.String("dir", "./logs", "directory containing log files")
 	ignoreCase  = flag.Bool("ignore-case", false, "perform case-insensitive search")
-	limit       = flag.Int("limit", 0, "limit number of results (returns newest N matches)")
+	limit       = flag.Int("limit", 0, "limit number of results")
+	latest      = flag.Bool("latest", false, "return globally latest N matches across all sources")
 	jsonMode    = flag.Bool("json", false, "parse logs as JSON (one JSON object per line)")
 	follow      = flag.Bool("follow", false, "follow logs in real time (like tail -f)")
 	key         = flag.String("key", "", "field key to match (e.g. request_id, trace_id, event_key)")
@@ -47,7 +48,7 @@ Examples:
   # Case-insensitive search
   reqlog --ignore-case abc123
 
-  # Limit results (latest 10 matches)
+  # Limit results
   reqlog --limit 10 abc123
 
   # Filter by key
@@ -105,6 +106,10 @@ func main() {
 		services = strings.Split(*service, ",")
 	}
 
+	if *latest && *limit == 0 {
+		log.Fatal("--latest requires --limit")
+	}
+
 	cfg := &scanner.ScanConfig{
 		Dir:         *dir,
 		SearchValue: SearchValue,
@@ -115,6 +120,7 @@ func main() {
 		Recursive:   *recursive,
 		Services:    services,
 		JSONMode:    *jsonMode,
+		Latest:      *latest,
 	}
 	scn, err := scanner.New(*source, scanner.NewLineProcessor(cfg, scanner.NewTimeParser()))
 	if err != nil {

--- a/internal/scanner/docker_scanner.go
+++ b/internal/scanner/docker_scanner.go
@@ -2,7 +2,6 @@ package scanner
 
 import (
 	"bufio"
-	"container/heap"
 	"context"
 	"fmt"
 	"io"
@@ -20,33 +19,30 @@ type DockerScanner struct {
 	dockerClient  docker.DockerClient
 	out           io.Writer
 	errOut        io.Writer
+	now           time.Time
 }
 
 func NewDockerScanner(lp *LineProcessor,
 	client docker.DockerClient,
 	out io.Writer,
 	errOut io.Writer,
+	now time.Time,
 ) *DockerScanner {
 	return &DockerScanner{
 		lineProcessor: lp,
 		dockerClient:  client,
 		out:           out,
 		errOut:        errOut,
+		now:           now,
 	}
 }
 
 func (ds *DockerScanner) Scan(containers []string) ([]domain.LogEntry, error) {
 	cfg := ds.lineProcessor.config
 
-	var h entryHeap
-	var results []domain.LogEntry
-	sinceTime, err := parseSince(cfg.Since, time.Now())
+	collector, err := NewEntryCollector(cfg, ds.now)
 	if err != nil {
 		return nil, err
-	}
-
-	if cfg.Limit > 0 {
-		heap.Init(&h)
 	}
 
 	for _, container := range containers {
@@ -58,23 +54,26 @@ func (ds *DockerScanner) Scan(containers []string) ([]domain.LogEntry, error) {
 
 		func() {
 			defer reader.Close()
+			collector.StartSource()
 
 			scanner := bufio.NewScanner(reader)
 			for scanner.Scan() {
 				line := scanner.Text()
+
 				entry, ok := ds.lineProcessor.ProcessLine(line, container)
-				if ok && passesSince(entry, sinceTime) {
-					ds.lineProcessor.AddEntry(*entry, &results, &h)
+				if !ok {
+					continue
+				}
+
+				continueReading := collector.Add(entry)
+				if !continueReading {
+					break
 				}
 			}
 		}()
 	}
 
-	if cfg.Limit > 0 {
-		results = drainHeap(&h)
-	}
-
-	return results, nil
+	return collector.Results(), nil
 }
 
 func (ds *DockerScanner) Follow(ctx context.Context, containers []string, f formatter.LogFormatter) {

--- a/internal/scanner/docker_scanner_test.go
+++ b/internal/scanner/docker_scanner_test.go
@@ -24,7 +24,7 @@ func dockerLogs(lines []string) io.ReadCloser {
 
 func newTestDockerScanner(cfg *ScanConfig, client docker.DockerClient) *DockerScanner {
 	lp := NewLineProcessor(cfg, NewTimeParser())
-	return NewDockerScanner(lp, client, io.Discard, io.Discard)
+	return NewDockerScanner(lp, client, io.Discard, io.Discard, time.Now())
 }
 
 func TestDockerScanner_Scan(t *testing.T) {
@@ -77,7 +77,7 @@ func TestDockerScanner_Scan(t *testing.T) {
 		{
 			name: "multi container with limit",
 			logsFn: func(container string, follow bool, since string) (io.ReadCloser, error) {
-				return dockerLogs([]string{"2024-03-10T12:00:00Z id=123", "2024-03-10T12:00:00Z id=123"}), nil
+				return dockerLogs([]string{"2024-03-10T12:00:00Z id=123", "2024-03-10T12:00:00Z id=123", "2024-03-10T12:00:00Z id=123"}), nil
 			},
 			cfg:        &ScanConfig{SearchValue: "123", Keys: []string{"id"}, Limit: 2},
 			containers: []string{"a", "b"},
@@ -116,7 +116,7 @@ func TestDockerScanner_Scan(t *testing.T) {
 
 			lp := NewLineProcessor(tt.cfg, NewTimeParser())
 			var out, errOut bytes.Buffer
-			ds := NewDockerScanner(lp, mock, &out, &errOut)
+			ds := NewDockerScanner(lp, mock, &out, &errOut, time.Now())
 
 			results, err := ds.Scan(tt.containers)
 			if err != nil {
@@ -216,6 +216,75 @@ func TestDockerScanner_Scan_JSON(t *testing.T) {
 				tt.assert(t, results)
 			}
 		})
+	}
+}
+
+func TestDockerScanner_Scan_Latest(t *testing.T) {
+	mock := &mockDockerClient{
+		logsFn: func(container string, follow bool, since string) (io.ReadCloser, error) {
+			switch container {
+			case "a":
+				return dockerLogs([]string{
+					"2024-03-10T12:00:01Z id=123",
+					"2024-03-10T12:00:03Z id=123",
+					"2024-03-10T12:00:05Z id=123",
+				}), nil
+
+			case "b":
+				return dockerLogs([]string{
+					"2024-03-10T12:00:02Z id=123",
+					"2024-03-10T12:00:04Z id=123",
+					"2024-03-10T12:00:06Z id=123",
+				}), nil
+			}
+
+			return dockerLogs(nil), nil
+		},
+		listFn: func() ([]string, error) {
+			return []string{"a", "b"}, nil
+		},
+	}
+
+	cfg := &ScanConfig{
+		SearchValue: "123",
+		Keys:        []string{"id"},
+		Limit:       2,
+		Latest:      true,
+	}
+
+	lp := NewLineProcessor(cfg, NewTimeParser())
+
+	var out, errOut bytes.Buffer
+	ds := NewDockerScanner(lp, mock, &out, &errOut, time.Now())
+
+	results, err := ds.Scan([]string{"a", "b"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(results) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(results))
+	}
+
+	expected := []string{
+		"2024-03-10T12:00:05Z",
+		"2024-03-10T12:00:06Z",
+	}
+
+	for i, ts := range expected {
+		expectedTime, err := time.Parse(time.RFC3339, ts)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if !results[i].Timestamp.Equal(expectedTime) {
+			t.Fatalf(
+				"result[%d]: expected %v, got %v",
+				i,
+				expectedTime,
+				results[i].Timestamp,
+			)
+		}
 	}
 }
 
@@ -352,7 +421,7 @@ func TestDockerScanner_Follow(t *testing.T) {
 			}
 
 			var out bytes.Buffer
-			ds := NewDockerScanner(lp, client, &out, io.Discard)
+			ds := NewDockerScanner(lp, client, &out, io.Discard, time.Now())
 
 			ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
 			defer cancel()
@@ -394,7 +463,7 @@ func TestDockerScanner_Follow_Errors(t *testing.T) {
 	var out bytes.Buffer
 	var errOut bytes.Buffer
 
-	ds := NewDockerScanner(lp, client, &out, &errOut)
+	ds := NewDockerScanner(lp, client, &out, &errOut, time.Now())
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()

--- a/internal/scanner/entry_collector.go
+++ b/internal/scanner/entry_collector.go
@@ -1,0 +1,93 @@
+package scanner
+
+import (
+	"container/heap"
+	"sort"
+	"time"
+
+	"github.com/sagarmaheshwary/reqlog/internal/domain"
+)
+
+type EntryCollector struct {
+	cfg       *ScanConfig
+	sinceTime time.Time
+	results   []domain.LogEntry
+	heap      entryHeap
+	//per-source count for default --limit mode
+	sourceCount int
+}
+
+func NewEntryCollector(cfg *ScanConfig, now time.Time) (*EntryCollector, error) {
+	sinceTime, err := parseSince(cfg.Since, now)
+	if err != nil {
+		return nil, err
+	}
+
+	c := &EntryCollector{
+		cfg:       cfg,
+		sinceTime: sinceTime,
+	}
+
+	if cfg.Latest {
+		heap.Init(&c.heap)
+	}
+
+	return c, nil
+}
+
+func (c *EntryCollector) StartSource() {
+	c.sourceCount = 0
+}
+
+func (c *EntryCollector) Add(entry *domain.LogEntry) bool {
+	if entry == nil {
+		return true
+	}
+
+	if !passesSince(entry, c.sinceTime) {
+		return true
+	}
+
+	// no limit
+	if c.cfg.Limit == 0 {
+		c.results = append(c.results, *entry)
+		return true
+	}
+
+	// --latest => global heap, scan everything
+	if c.cfg.Latest {
+		if c.heap.Len() < c.cfg.Limit {
+			heap.Push(&c.heap, *entry)
+		} else if entry.Timestamp.After(c.heap[0].Timestamp) {
+			heap.Pop(&c.heap)
+			heap.Push(&c.heap, *entry)
+		}
+
+		return true
+	}
+
+	//default --limit => early exit per source
+	if c.sourceCount < c.cfg.Limit {
+		c.results = append(c.results, *entry)
+		c.sourceCount++
+	}
+
+	//stop scanning this source once enough matches found
+	return c.sourceCount < c.cfg.Limit
+}
+
+func (c *EntryCollector) Results() []domain.LogEntry {
+	if c.cfg.Limit > 0 && c.cfg.Latest {
+		c.results = drainHeap(&c.heap)
+	}
+
+	sort.Slice(c.results, func(i, j int) bool {
+		return c.results[i].Timestamp.Before(c.results[j].Timestamp)
+	})
+
+	if c.cfg.Limit > 0 && !c.cfg.Latest && len(c.results) > c.cfg.Limit {
+		c.results = c.results[len(c.results)-c.cfg.Limit:]
+	}
+
+	return c.results
+}

--- a/internal/scanner/entry_collector_test.go
+++ b/internal/scanner/entry_collector_test.go
@@ -1,0 +1,249 @@
+package scanner
+
+import (
+	"testing"
+	"time"
+
+	"github.com/sagarmaheshwary/reqlog/internal/domain"
+)
+
+func newEntry(ts int64, service string) *domain.LogEntry {
+	return &domain.LogEntry{
+		Timestamp: time.Unix(ts, 0),
+		Service:   service,
+		Message:   "msg",
+	}
+}
+
+func timestamps(entries []domain.LogEntry) []int64 {
+	out := make([]int64, 0, len(entries))
+
+	for _, e := range entries {
+		out = append(out, e.Timestamp.Unix())
+	}
+
+	return out
+}
+
+func TestNewEntryCollector(t *testing.T) {
+	now := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name      string
+		cfg       *ScanConfig
+		expectErr bool
+	}{
+		{
+			name: "valid without latest",
+			cfg: &ScanConfig{
+				Limit: 10,
+			},
+		},
+		{
+			name: "invalid since",
+			cfg: &ScanConfig{
+				Since: "invalid",
+			},
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := NewEntryCollector(tt.cfg, now)
+
+			if tt.expectErr {
+				if err == nil {
+					t.Fatalf("expected error")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestEntryCollector_Add_NoLimit(t *testing.T) {
+	cfg := &ScanConfig{
+		Limit: 0,
+	}
+
+	c, err := NewEntryCollector(cfg, time.Now())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	entries := []*domain.LogEntry{
+		newEntry(1, "svc"),
+		newEntry(2, "svc"),
+		newEntry(3, "svc"),
+	}
+
+	for _, e := range entries {
+		ok := c.Add(e)
+
+		if !ok {
+			t.Fatalf("expected continue=true")
+		}
+	}
+
+	got := timestamps(c.Results())
+	expected := []int64{1, 2, 3}
+
+	for i := range expected {
+		if got[i] != expected[i] {
+			t.Fatalf("expected %v, got %v", expected, got)
+		}
+	}
+}
+
+func TestEntryCollector_Add_DefaultLimit(t *testing.T) {
+	cfg := &ScanConfig{
+		Limit: 2,
+	}
+
+	c, err := NewEntryCollector(cfg, time.Now())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	c.StartSource()
+
+	tests := []struct {
+		entry          *domain.LogEntry
+		expectContinue bool
+	}{
+		{
+			entry:          newEntry(1, "svc"),
+			expectContinue: true,
+		},
+		{
+			entry:          newEntry(2, "svc"),
+			expectContinue: false,
+		},
+		{
+			entry:          newEntry(3, "svc"),
+			expectContinue: false,
+		},
+	}
+
+	for _, tt := range tests {
+		got := c.Add(tt.entry)
+
+		if got != tt.expectContinue {
+			t.Fatalf("expected continue=%v, got %v",
+				tt.expectContinue, got)
+		}
+	}
+
+	got := timestamps(c.Results())
+	expected := []int64{1, 2}
+
+	for i := range expected {
+		if got[i] != expected[i] {
+			t.Fatalf("expected %v, got %v", expected, got)
+		}
+	}
+}
+
+func TestEntryCollector_Add_Latest(t *testing.T) {
+	cfg := &ScanConfig{
+		Limit:  2,
+		Latest: true,
+	}
+
+	c, err := NewEntryCollector(cfg, time.Now())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	entries := []*domain.LogEntry{
+		newEntry(1, "svc"),
+		newEntry(3, "svc"),
+		newEntry(2, "svc"),
+	}
+
+	for _, e := range entries {
+		ok := c.Add(e)
+
+		if !ok {
+			t.Fatalf("expected continue=true")
+		}
+	}
+
+	got := timestamps(c.Results())
+	expected := []int64{2, 3}
+
+	for i := range expected {
+		if got[i] != expected[i] {
+			t.Fatalf("expected %v, got %v", expected, got)
+		}
+	}
+}
+
+func TestEntryCollector_Add_SinceFiltering(t *testing.T) {
+	now := time.Unix(100, 0)
+
+	cfg := &ScanConfig{
+		Since: "10s",
+	}
+
+	c, err := NewEntryCollector(cfg, now)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	c.Add(newEntry(80, "svc")) // filtered out
+	c.Add(newEntry(95, "svc")) // included
+
+	got := timestamps(c.Results())
+	expected := []int64{95}
+
+	if len(got) != len(expected) {
+		t.Fatalf("expected %v, got %v", expected, got)
+	}
+
+	if got[0] != expected[0] {
+		t.Fatalf("expected %v, got %v", expected, got)
+	}
+}
+
+func TestEntryCollector_Add_NilEntry(t *testing.T) {
+	c, err := NewEntryCollector(&ScanConfig{}, time.Now())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	ok := c.Add(nil)
+
+	if !ok {
+		t.Fatalf("expected continue=true")
+	}
+
+	if len(c.Results()) != 0 {
+		t.Fatalf("expected no results")
+	}
+}
+
+func TestEntryCollector_Results_Sorted(t *testing.T) {
+	c, err := NewEntryCollector(&ScanConfig{}, time.Now())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	c.Add(newEntry(3, "svc"))
+	c.Add(newEntry(1, "svc"))
+	c.Add(newEntry(2, "svc"))
+
+	got := timestamps(c.Results())
+	expected := []int64{1, 2, 3}
+
+	for i := range expected {
+		if got[i] != expected[i] {
+			t.Fatalf("expected %v, got %v", expected, got)
+		}
+	}
+}

--- a/internal/scanner/factory.go
+++ b/internal/scanner/factory.go
@@ -11,9 +11,9 @@ import (
 func New(source string, lp *LineProcessor) (Scanner, error) {
 	switch source {
 	case "file":
-		return NewFileScanner(lp, time.Second, os.Stdout, os.Stderr), nil
+		return NewFileScanner(lp, time.Second, os.Stdout, os.Stderr, time.Now()), nil
 	case "docker":
-		return NewDockerScanner(lp, docker.NewDockerCLIClient(), os.Stdout, os.Stderr), nil
+		return NewDockerScanner(lp, docker.NewDockerCLIClient(), os.Stdout, os.Stderr, time.Now()), nil
 	default:
 		return nil, fmt.Errorf("unknown source type")
 	}

--- a/internal/scanner/file_scanner.go
+++ b/internal/scanner/file_scanner.go
@@ -2,7 +2,6 @@ package scanner
 
 import (
 	"bufio"
-	"container/heap"
 	"context"
 	"fmt"
 	"io"
@@ -25,6 +24,7 @@ type ScanConfig struct {
 	Recursive   bool
 	Services    []string
 	JSONMode    bool
+	Latest      bool
 }
 
 type FileScanner struct {
@@ -33,6 +33,7 @@ type FileScanner struct {
 	followInterval time.Duration
 	out            io.Writer
 	errOut         io.Writer
+	now            time.Time
 }
 
 func NewFileScanner(
@@ -40,27 +41,24 @@ func NewFileScanner(
 	followInterval time.Duration,
 	out io.Writer,
 	errOut io.Writer,
+	now time.Time,
 ) *FileScanner {
 	return &FileScanner{
 		offsets:        make(map[string]int64),
 		lineProcessor:  lp,
-		followInterval: followInterval, // default
+		followInterval: followInterval,
 		out:            out,
 		errOut:         errOut,
+		now:            now,
 	}
 }
 
 func (fs *FileScanner) Scan(files []string) ([]domain.LogEntry, error) {
-	var h entryHeap
-	var results []domain.LogEntry
 	cfg := fs.lineProcessor.config
-	sinceTime, err := parseSince(cfg.Since, time.Now())
+
+	collector, err := NewEntryCollector(cfg, fs.now)
 	if err != nil {
 		return nil, err
-	}
-
-	if cfg.Limit > 0 {
-		heap.Init(&h)
 	}
 
 	for _, path := range files {
@@ -72,6 +70,7 @@ func (fs *FileScanner) Scan(files []string) ([]domain.LogEntry, error) {
 
 		offset, err := func() (int64, error) {
 			defer file.Close()
+			collector.StartSource()
 
 			service := strings.TrimSuffix(filepath.Base(path), ".log")
 			reader := bufio.NewReader(file)
@@ -84,8 +83,13 @@ func (fs *FileScanner) Scan(files []string) ([]domain.LogEntry, error) {
 					offset += int64(len(line))
 
 					entry, ok := fs.lineProcessor.ProcessLine(line, service)
-					if ok && passesSince(entry, sinceTime) {
-						fs.lineProcessor.AddEntry(*entry, &results, &h)
+					if !ok {
+						continue
+					}
+
+					continueReading := collector.Add(entry)
+					if !continueReading {
+						break
 					}
 				}
 
@@ -107,11 +111,7 @@ func (fs *FileScanner) Scan(files []string) ([]domain.LogEntry, error) {
 		fs.offsets[path] = offset
 	}
 
-	if cfg.Limit > 0 {
-		results = drainHeap(&h)
-	}
-
-	return results, nil
+	return collector.Results(), nil
 }
 
 func (fs *FileScanner) Follow(ctx context.Context, files []string, f formatter.LogFormatter) {

--- a/internal/scanner/file_scanner_benchmark_test.go
+++ b/internal/scanner/file_scanner_benchmark_test.go
@@ -84,7 +84,7 @@ func BenchmarkScanDir_PlainText(b *testing.B) {
 		}
 		lp := NewLineProcessor(cfg, NewTimeParser())
 
-		fs := NewFileScanner(lp, time.Second, os.Stdout, os.Stderr)
+		fs := NewFileScanner(lp, time.Second, os.Stdout, os.Stderr, time.Now())
 		files, err := fs.ListSources()
 		if err != nil {
 			b.Fatal(err)
@@ -117,7 +117,7 @@ func BenchmarkScanDir_JSON(b *testing.B) {
 		}
 		lp := NewLineProcessor(cfg, NewTimeParser())
 
-		fs := NewFileScanner(lp, time.Second, os.Stdout, os.Stderr)
+		fs := NewFileScanner(lp, time.Second, os.Stdout, os.Stderr, time.Now())
 		files, err := fs.ListSources()
 		if err != nil {
 			b.Fatal(err)

--- a/internal/scanner/file_scanner_test.go
+++ b/internal/scanner/file_scanner_test.go
@@ -15,7 +15,7 @@ import (
 
 func newTestFileScanner(cfg *ScanConfig) *FileScanner {
 	lp := NewLineProcessor(cfg, NewTimeParser())
-	return NewFileScanner(lp, time.Second, io.Discard, io.Discard)
+	return NewFileScanner(lp, time.Second, io.Discard, io.Discard, time.Now())
 }
 
 func writeFile(t *testing.T, path string, content []byte) {
@@ -41,7 +41,7 @@ func TestFileScanner_Scan(t *testing.T) {
 		Keys:        []string{"user"},
 	}
 	lp := NewLineProcessor(cfg, NewTimeParser())
-	fs := NewFileScanner(lp, time.Second, io.Discard, io.Discard)
+	fs := NewFileScanner(lp, time.Second, io.Discard, io.Discard, time.Now())
 
 	files, err := fs.ListSources()
 	if err != nil {
@@ -83,7 +83,7 @@ func TestFileScanner_Scan_WithSince(t *testing.T) {
 	}
 	lp := NewLineProcessor(cfg, NewTimeParser())
 
-	fs := NewFileScanner(lp, time.Second, io.Discard, io.Discard)
+	fs := NewFileScanner(lp, time.Second, io.Discard, io.Discard, time.Now())
 	files, err := fs.ListSources()
 	if err != nil {
 		t.Fatal(err)
@@ -112,7 +112,7 @@ func TestFileScanner_Scan_IgnoreCase(t *testing.T) {
 	}
 	lp := NewLineProcessor(cfg, NewTimeParser())
 
-	fs := NewFileScanner(lp, time.Second, io.Discard, io.Discard)
+	fs := NewFileScanner(lp, time.Second, io.Discard, io.Discard, time.Now())
 	files, err := fs.ListSources()
 	if err != nil {
 		t.Fatal(err)
@@ -140,7 +140,7 @@ func TestFileScanner_Scan_IgnoresNonLogFiles(t *testing.T) {
 	}
 	lp := NewLineProcessor(cfg, NewTimeParser())
 
-	fs := NewFileScanner(lp, time.Second, io.Discard, io.Discard)
+	fs := NewFileScanner(lp, time.Second, io.Discard, io.Discard, time.Now())
 	files, err := fs.ListSources()
 	if err != nil {
 		t.Fatal(err)
@@ -155,14 +155,23 @@ func TestFileScanner_Scan_IgnoresNonLogFiles(t *testing.T) {
 	}
 }
 
-func TestScan_MultiFile_GlobalLimit(t *testing.T) {
+func TestScan_MultiFile_Limit(t *testing.T) {
 	dir := t.TempDir()
 
 	file1 := filepath.Join(dir, "a.log")
 	file2 := filepath.Join(dir, "b.log")
 
-	writeFile(t, file1, []byte("2024-03-10T12:00:00Z id=123\nid=123\n"))
-	writeFile(t, file2, []byte("2024-03-10T12:00:00Z id=123\nid=123\n"))
+	writeFile(t, file1, []byte(`
+2024-03-10T12:00:01Z id=123
+2024-03-10T12:00:03Z id=123
+2024-03-10T12:00:05Z id=123
+`))
+
+	writeFile(t, file2, []byte(`
+2024-03-10T12:00:02Z id=123
+2024-03-10T12:00:04Z id=123
+2024-03-10T12:00:06Z id=123
+`))
 
 	cfg := &ScanConfig{
 		SearchValue: "123",
@@ -178,6 +187,64 @@ func TestScan_MultiFile_GlobalLimit(t *testing.T) {
 
 	if len(results) != 2 {
 		t.Fatalf("expected 2 results, got %d", len(results))
+	}
+}
+
+func TestScan_MultiFile_Latest(t *testing.T) {
+	dir := t.TempDir()
+
+	file1 := filepath.Join(dir, "a.log")
+	file2 := filepath.Join(dir, "b.log")
+
+	writeFile(t, file1, []byte(`
+2024-03-10T12:00:01Z id=123
+2024-03-10T12:00:03Z id=123
+2024-03-10T12:00:05Z id=123
+`))
+
+	writeFile(t, file2, []byte(`
+2024-03-10T12:00:02Z id=123
+2024-03-10T12:00:04Z id=123
+2024-03-10T12:00:06Z id=123
+`))
+
+	cfg := &ScanConfig{
+		SearchValue: "123",
+		Keys:        []string{"id"},
+		Limit:       2,
+		Latest:      true,
+	}
+
+	fs := newTestFileScanner(cfg)
+
+	results, err := fs.Scan([]string{file1, file2})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(results) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(results))
+	}
+
+	expected := []string{
+		"2024-03-10T12:00:05Z",
+		"2024-03-10T12:00:06Z",
+	}
+
+	for i, ts := range expected {
+		expectedTime, err := time.Parse(time.RFC3339, ts)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if !results[i].Timestamp.Equal(expectedTime) {
+			t.Fatalf(
+				"result[%d]: expected %v, got %v",
+				i,
+				expectedTime,
+				results[i].Timestamp,
+			)
+		}
 	}
 }
 
@@ -239,7 +306,7 @@ func TestFileScanner_Scan_ErrorLogging(t *testing.T) {
 
 	var out bytes.Buffer
 	var errOut bytes.Buffer
-	fs := NewFileScanner(lp, time.Second, &out, &errOut)
+	fs := NewFileScanner(lp, time.Second, &out, &errOut, time.Now())
 
 	results, err := fs.Scan(files)
 	if err != nil {
@@ -317,7 +384,7 @@ func TestFileScanner_Scan_JSON(t *testing.T) {
 			}
 
 			lp := NewLineProcessor(cfg, NewTimeParser())
-			fs := NewFileScanner(lp, time.Second, io.Discard, io.Discard)
+			fs := NewFileScanner(lp, time.Second, io.Discard, io.Discard, time.Now())
 
 			files, err := fs.ListSources()
 			if err != nil {
@@ -491,7 +558,7 @@ func TestFileScanner_Follow(t *testing.T) {
 
 			cfg := &ScanConfig{SearchValue: "123", Keys: []string{"user"}}
 			lp := NewLineProcessor(cfg, NewTimeParser())
-			fs := NewFileScanner(lp, 10*time.Millisecond, &out, io.Discard)
+			fs := NewFileScanner(lp, 10*time.Millisecond, &out, io.Discard, time.Now())
 
 			ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
 			defer cancel()
@@ -533,7 +600,7 @@ func TestFileScanner_Follow_Errors(t *testing.T) {
 
 	var out bytes.Buffer
 	var errOut bytes.Buffer
-	fs := NewFileScanner(lp, 10*time.Millisecond, &out, &errOut)
+	fs := NewFileScanner(lp, 10*time.Millisecond, &out, &errOut, time.Now())
 
 	// pass a missing file to trigger error
 	files := []string{"/tmp/nonexistent.log"}

--- a/internal/scanner/line_processor.go
+++ b/internal/scanner/line_processor.go
@@ -1,7 +1,6 @@
 package scanner
 
 import (
-	"container/heap"
 	"sort"
 	"strings"
 	"sync"
@@ -95,27 +94,6 @@ func (lp *LineProcessor) processTextLine(line string, service string) (*domain.L
 		Service:   service,
 		Message:   extractTextMessage(line),
 	}, true
-}
-
-func (lp *LineProcessor) AddEntry(
-	entry domain.LogEntry,
-	results *[]domain.LogEntry,
-	h *entryHeap,
-) {
-	if lp.config.Limit <= 0 {
-		*results = append(*results, entry)
-		return
-	}
-
-	if h.Len() < lp.config.Limit {
-		heap.Push(h, entry)
-		return
-	}
-
-	if entry.Timestamp.After((*h)[0].Timestamp) {
-		heap.Pop(h)
-		heap.Push(h, entry)
-	}
 }
 
 func (lp *LineProcessor) extractJSONTimestampValue(

--- a/internal/scanner/line_processor_test.go
+++ b/internal/scanner/line_processor_test.go
@@ -1,13 +1,9 @@
 package scanner
 
 import (
-	"container/heap"
-	"sort"
 	"strings"
 	"testing"
-	"time"
 
-	"github.com/sagarmaheshwary/reqlog/internal/domain"
 	"github.com/tidwall/gjson"
 )
 
@@ -184,76 +180,6 @@ func TestLineProcessor_ProcessLine_JSONMode(t *testing.T) {
 			if ok {
 				if entry.Service != "svc" {
 					t.Fatalf("unexpected service")
-				}
-			}
-		})
-	}
-}
-
-func TestLineProcessor_AddEntry(t *testing.T) {
-	tests := []struct {
-		name   string
-		limit  int
-		inputs []int64 // timestamps
-		expect []int64
-	}{
-		{
-			name:   "no limit",
-			limit:  0,
-			inputs: []int64{1, 2, 3},
-			expect: []int64{1, 2, 3},
-		},
-		{
-			name:   "limit keeps latest",
-			limit:  2,
-			inputs: []int64{1, 2, 3},
-			expect: []int64{2, 3},
-		},
-		{
-			name:   "limit with unordered input",
-			limit:  2,
-			inputs: []int64{3, 1, 2},
-			expect: []int64{2, 3},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			cfg := &ScanConfig{Limit: tt.limit}
-			lp := NewLineProcessor(cfg, nil)
-
-			var results []domain.LogEntry
-			h := &entryHeap{}
-			heap.Init(h)
-
-			for _, ts := range tt.inputs {
-				entry := domain.LogEntry{
-					Timestamp: time.Unix(ts, 0),
-				}
-				lp.AddEntry(entry, &results, h)
-			}
-
-			var got []int64
-
-			if tt.limit <= 0 {
-				for _, e := range results {
-					got = append(got, e.Timestamp.Unix())
-				}
-			} else {
-				for _, e := range *h {
-					got = append(got, e.Timestamp.Unix())
-				}
-			}
-
-			sort.Slice(got, func(i, j int) bool { return got[i] < got[j] })
-
-			if len(got) != len(tt.expect) {
-				t.Fatalf("expected %v, got %v", tt.expect, got)
-			}
-
-			for i := range got {
-				if got[i] != tt.expect[i] {
-					t.Fatalf("expected %v, got %v", tt.expect, got)
 				}
 			}
 		})


### PR DESCRIPTION
## Summary

This PR improves `--limit` performance for common log tracing workflows and adds a new `--latest` flag for globally latest results.

Previously, `--limit` scanned all matching entries across all files/containers to guarantee globally latest results.

That behavior was accurate, but expensive for large sources.

## New behavior

### Default `--limit`

When `--limit` is used without `--latest`:

- each source is scanned oldest → newest
- up to `N` matching entries are collected per source
- collected entries are merged across all sources
- results are sorted globally by timestamp
- final `N` entries are returned

This improves performance while preserving cross-source visibility when building timelines.

### `--latest`

A new `--latest` flag preserves the previous globally latest behavior.

When `--limit` is used with `--latest`:

- all matching entries across all sources are scanned
- a min-heap keeps the globally latest `N` entries
- final results are returned sorted by timestamp

`--latest` requires `--limit`.

## Internal changes

- introduced `EntryCollector` to centralize collection logic
- moved limit/latest handling out of `LineProcessor`
- removed `addEntry` from `LineProcessor`
- simplified result collection flow in `FileScanner` and `DockerScanner`

## Tests

- updated `--limit` scan behavior tests
- added `--latest` coverage for both `FileScanner` and `DockerScanner`