### PR TITLE
feat: add --context flag with reusable context engine and scanner refactor

### DIFF
--- a/cmd/reqlog/main.go
+++ b/cmd/reqlog/main.go
@@ -27,7 +27,8 @@ var (
 	recursive   = flag.Bool("recursive", true, "scan directories recursively")
 	service     = flag.String("service", "", "filter by service name (comma-separated, e.g. order-service,inventory-service)")
 	source      = flag.String("source", "file", `log source backend: "file", "docker"`)
-	showVersion = flag.Bool("version", false, "print version and exit")
+	versionFlag = flag.Bool("version", false, "print version and exit")
+	contextFlag = flag.Int("context", 0, "show N lines of context before and after each match")
 )
 
 var version = "dev"
@@ -82,7 +83,7 @@ Examples:
 func main() {
 	flag.Parse()
 
-	if *showVersion {
+	if *versionFlag {
 		fmt.Printf("reqlog version %s\n", cliVersion())
 		return
 	}
@@ -121,6 +122,7 @@ func main() {
 		Services:    services,
 		JSONMode:    *jsonMode,
 		Latest:      *latest,
+		Context:     *contextFlag,
 	}
 	scn, err := scanner.New(*source, scanner.NewLineProcessor(cfg, scanner.NewTimeParser()))
 	if err != nil {

--- a/cmd/reqlog/main.go
+++ b/cmd/reqlog/main.go
@@ -111,7 +111,7 @@ func main() {
 		log.Fatal("--latest requires --limit")
 	}
 
-	cfg := &scanner.ScanConfig{
+	cfg := &scanner.Config{
 		Dir:         *dir,
 		SearchValue: SearchValue,
 		IgnoreCase:  *ignoreCase,

--- a/internal/domain/logentry.go
+++ b/internal/domain/logentry.go
@@ -6,4 +6,5 @@ type LogEntry struct {
 	Timestamp time.Time
 	Service   string
 	Message   string
+	IsContext bool
 }

--- a/internal/formatter/formatter.go
+++ b/internal/formatter/formatter.go
@@ -43,9 +43,16 @@ func (f *Formatter) Format(entry domain.LogEntry) string {
 	serviceColor := f.colorizer.Color(entry.Service)
 	padding := f.padAfter(entry.Service)
 
+	msg := f.formatMessage(entry.Message)
+
+	if entry.IsContext {
+		msg = dim + msg + reset
+	}
+
 	return fmt.Sprintf(
 		"%s%s%s%s %s[%s]%s%s | %s%s%s",
-		dim, tsColor,
+		dim,
+		tsColor,
 		entry.Timestamp.Format(tsFormat),
 		reset,
 
@@ -55,7 +62,7 @@ func (f *Formatter) Format(entry domain.LogEntry) string {
 		padding,
 
 		msgColor,
-		f.formatMessage(entry.Message),
+		msg,
 		reset,
 	)
 }

--- a/internal/formatter/formatter_test.go
+++ b/internal/formatter/formatter_test.go
@@ -240,3 +240,35 @@ func TestSortKVByPriority(t *testing.T) {
 		})
 	}
 }
+
+func TestFormatter_Format_ContextEntry(t *testing.T) {
+	f := NewFormatter(nil, nil)
+
+	entry := domain.LogEntry{
+		Timestamp: mustParseTime(t, "2024-03-10T12:00:00Z"),
+		Service:   "auth",
+		Message:   "user=123 status=ok",
+		IsContext: true,
+	}
+
+	got := f.Format(entry)
+
+	if !strings.Contains(got, dim) {
+		t.Fatalf("expected formatted output to contain dim ANSI code, got %q", got)
+	}
+
+	if !strings.Contains(got, "user") {
+		t.Fatalf("expected formatted output to contain message fields, got %q", got)
+	}
+}
+
+func mustParseTime(t *testing.T, s string) time.Time {
+	t.Helper()
+
+	ts, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return ts
+}

--- a/internal/scanner/config.go
+++ b/internal/scanner/config.go
@@ -1,0 +1,15 @@
+package scanner
+
+type Config struct {
+	Dir         string
+	SearchValue string
+	IgnoreCase  bool
+	Keys        []string
+	Since       string
+	Limit       int
+	Recursive   bool
+	Services    []string
+	JSONMode    bool
+	Latest      bool
+	Context     int
+}

--- a/internal/scanner/context_engine.go
+++ b/internal/scanner/context_engine.go
@@ -1,0 +1,84 @@
+package scanner
+
+import "github.com/sagarmaheshwary/reqlog/internal/domain"
+
+type contextEngine struct {
+	beforeBuf      *ringBuffer
+	lineProcessor  *LineProcessor
+	entryCollector *EntryCollector
+	contextSize    int
+	afterRemaining int
+	stopAfterMatch bool
+}
+
+type ContextLine struct {
+	Line    string
+	Service string
+	Entry   *domain.LogEntry
+	IsMatch bool
+}
+
+func NewContextEngine(lp *LineProcessor, ec *EntryCollector, size int) *contextEngine {
+	var beforeBuf *ringBuffer
+
+	if size > 0 {
+		beforeBuf = NewRingBuffer(size)
+	}
+
+	return &contextEngine{
+		contextSize:    size,
+		beforeBuf:      beforeBuf,
+		lineProcessor:  lp,
+		entryCollector: ec,
+	}
+}
+
+func (c *contextEngine) Handle(in ContextLine) bool {
+	if c.contextSize == 0 {
+		if !in.IsMatch {
+			return true
+		}
+		return c.entryCollector.Add(in.Entry)
+	}
+
+	if in.IsMatch && !c.stopAfterMatch {
+		for _, e := range c.beforeBuf.Drain() {
+			e.IsContext = true
+			c.entryCollector.AddContext(&e)
+		}
+
+		continueReading := c.entryCollector.Add(in.Entry)
+		if !continueReading {
+			c.stopAfterMatch = true
+		}
+
+		c.afterRemaining = c.contextSize
+
+		return true
+	}
+
+	entry, ok := c.lineProcessor.ParseOnly(in.Line, in.Service)
+	if !ok {
+		return true
+	}
+
+	entry.IsContext = true
+	wasAfterContext := false
+
+	if c.afterRemaining > 0 {
+		c.entryCollector.AddContext(entry)
+
+		c.afterRemaining--
+		wasAfterContext = true
+	}
+
+	if c.beforeBuf != nil && !wasAfterContext {
+		c.beforeBuf.Push(*entry)
+	}
+
+	if c.stopAfterMatch && c.afterRemaining == 0 {
+		return false
+	}
+
+	return true
+}

--- a/internal/scanner/context_engine_test.go
+++ b/internal/scanner/context_engine_test.go
@@ -12,7 +12,7 @@ func TestContextEngine_Handle(t *testing.T) {
 	tests := []struct {
 		name             string
 		contextSize      int
-		cfg              *ScanConfig
+		cfg              *Config
 		inputs           []ContextLine
 		expectedMessages []string
 		expectedContext  []bool
@@ -21,7 +21,7 @@ func TestContextEngine_Handle(t *testing.T) {
 		{
 			name:        "no context mode only collects matches",
 			contextSize: 0,
-			cfg: &ScanConfig{
+			cfg: &Config{
 				Limit: 10,
 			},
 			inputs: []ContextLine{
@@ -55,7 +55,7 @@ func TestContextEngine_Handle(t *testing.T) {
 		{
 			name:        "before and after context",
 			contextSize: 1,
-			cfg: &ScanConfig{
+			cfg: &Config{
 				Limit:       10,
 				Keys:        []string{"user"},
 				Context:     1,
@@ -102,7 +102,7 @@ func TestContextEngine_Handle(t *testing.T) {
 		{
 			name:        "stops after trailing context exhausted",
 			contextSize: 1,
-			cfg: &ScanConfig{
+			cfg: &Config{
 				Limit:   1,
 				Keys:    []string{"user"},
 				Context: 1,
@@ -138,7 +138,7 @@ func TestContextEngine_Handle(t *testing.T) {
 		{
 			name:        "invalid context line is skipped",
 			contextSize: 1,
-			cfg: &ScanConfig{
+			cfg: &Config{
 				Limit:   10,
 				Keys:    []string{"user"},
 				Context: 1,

--- a/internal/scanner/context_engine_test.go
+++ b/internal/scanner/context_engine_test.go
@@ -1,0 +1,222 @@
+package scanner
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/sagarmaheshwary/reqlog/internal/domain"
+)
+
+func TestContextEngine_Handle(t *testing.T) {
+	tests := []struct {
+		name             string
+		contextSize      int
+		cfg              *ScanConfig
+		inputs           []ContextLine
+		expectedMessages []string
+		expectedContext  []bool
+		expectedContinue []bool
+	}{
+		{
+			name:        "no context mode only collects matches",
+			contextSize: 0,
+			cfg: &ScanConfig{
+				Limit: 10,
+			},
+			inputs: []ContextLine{
+				{
+					Line:    "2024-03-10T12:00:00Z user=ignore",
+					Service: "svc",
+					IsMatch: false,
+				},
+				{
+					Line:    "2024-03-10T12:00:01Z user=123",
+					Service: "svc",
+					IsMatch: true,
+					Entry: &domain.LogEntry{
+						Message:   "user=123",
+						Timestamp: mustParseRFC3339("2024-03-10T12:00:01Z"),
+						Service:   "svc",
+					},
+				},
+			},
+			expectedMessages: []string{
+				"user=123",
+			},
+			expectedContext: []bool{
+				false,
+			},
+			expectedContinue: []bool{
+				true,
+				true,
+			},
+		},
+		{
+			name:        "before and after context",
+			contextSize: 1,
+			cfg: &ScanConfig{
+				Limit:       10,
+				Keys:        []string{"user"},
+				Context:     1,
+				SearchValue: "123",
+			},
+			inputs: []ContextLine{
+				{
+					Line:    "2024-03-10T12:00:00Z user=before",
+					Service: "svc",
+					IsMatch: false,
+				},
+				{
+					Line:    "2024-03-10T12:00:01Z user=123",
+					Service: "svc",
+					IsMatch: true,
+					Entry: &domain.LogEntry{
+						Message:   "user=123",
+						Timestamp: mustParseRFC3339("2024-03-10T12:00:01Z"),
+						Service:   "svc",
+					},
+				},
+				{
+					Line:    "2024-03-10T12:00:02Z user=after",
+					Service: "svc",
+					IsMatch: false,
+				},
+			},
+			expectedMessages: []string{
+				"user=before",
+				"user=123",
+				"user=after",
+			},
+			expectedContext: []bool{
+				true,
+				false,
+				true,
+			},
+			expectedContinue: []bool{
+				true,
+				true,
+				true,
+			},
+		},
+		{
+			name:        "stops after trailing context exhausted",
+			contextSize: 1,
+			cfg: &ScanConfig{
+				Limit:   1,
+				Keys:    []string{"user"},
+				Context: 1,
+			},
+			inputs: []ContextLine{
+				{
+					Line:    "2024-03-10T12:00:00Z user=123",
+					Service: "svc",
+					IsMatch: true,
+					Entry: &domain.LogEntry{
+						Message: "user=123",
+					},
+				},
+				{
+					Line:    "2024-03-10T12:00:01Z user=after",
+					Service: "svc",
+					IsMatch: false,
+				},
+			},
+			expectedMessages: []string{
+				"user=123",
+				"user=after",
+			},
+			expectedContext: []bool{
+				false,
+				true,
+			},
+			expectedContinue: []bool{
+				true,
+				false,
+			},
+		},
+		{
+			name:        "invalid context line is skipped",
+			contextSize: 1,
+			cfg: &ScanConfig{
+				Limit:   10,
+				Keys:    []string{"user"},
+				Context: 1,
+			},
+			inputs: []ContextLine{
+				{
+					Line:    "invalid log line",
+					Service: "svc",
+					IsMatch: false,
+				},
+			},
+			expectedMessages: nil,
+			expectedContext:  nil,
+			expectedContinue: []bool{
+				true,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lp := NewLineProcessor(tt.cfg, NewTimeParser())
+
+			collector, err := NewEntryCollector(tt.cfg, time.Now())
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			engine := NewContextEngine(
+				lp,
+				collector,
+				tt.contextSize,
+			)
+
+			var continues []bool
+
+			for _, in := range tt.inputs {
+				continues = append(continues, engine.Handle(in))
+			}
+
+			results := collector.Results()
+
+			if !reflect.DeepEqual(continues, tt.expectedContinue) {
+				t.Fatalf(
+					"expected continue=%v, got %v",
+					tt.expectedContinue,
+					continues,
+				)
+			}
+
+			if len(results) != len(tt.expectedMessages) {
+				t.Fatalf(
+					"expected %d results, got %d",
+					len(tt.expectedMessages),
+					len(results),
+				)
+			}
+
+			for i, result := range results {
+				if result.Message != tt.expectedMessages[i] {
+					t.Fatalf(
+						"result[%d]: expected message %q, got %q. %v",
+						i,
+						tt.expectedMessages[i],
+						result.Message,
+						results,
+					)
+				}
+
+				if result.IsContext != tt.expectedContext[i] {
+					t.Fatalf(
+						"result[%d]: expected IsContext=%v, got %v",
+						i,
+						tt.expectedContext[i],
+						result.IsContext,
+					)
+				}
+			}
+		})
+	}
+}

--- a/internal/scanner/docker_scanner.go
+++ b/internal/scanner/docker_scanner.go
@@ -55,17 +55,19 @@ func (ds *DockerScanner) Scan(containers []string) ([]domain.LogEntry, error) {
 		func() {
 			defer reader.Close()
 			collector.StartSource()
+			engine := NewContextEngine(ds.lineProcessor, collector, cfg.Context)
 
 			scanner := bufio.NewScanner(reader)
 			for scanner.Scan() {
 				line := scanner.Text()
 
 				entry, ok := ds.lineProcessor.ProcessLine(line, container)
-				if !ok {
-					continue
-				}
-
-				continueReading := collector.Add(entry)
+				continueReading := engine.Handle(ContextLine{
+					Line:    line,
+					Service: container,
+					Entry:   entry,
+					IsMatch: ok,
+				})
 				if !continueReading {
 					break
 				}

--- a/internal/scanner/docker_scanner_test.go
+++ b/internal/scanner/docker_scanner_test.go
@@ -288,6 +288,93 @@ func TestDockerScanner_Scan_Latest(t *testing.T) {
 	}
 }
 
+func TestDockerScanner_Scan_Context(t *testing.T) {
+	mock := &mockDockerClient{
+		logsFn: func(container string, follow bool, since string) (io.ReadCloser, error) {
+			return dockerLogs([]string{
+				"2024-03-10T12:00:00Z user=ignore",
+				"2024-03-10T12:00:01Z user=123",
+				"2024-03-10T12:00:02Z user=ignore",
+				"2024-03-10T12:00:03Z user=ignore",
+				"2024-03-10T12:00:04Z user=123", // should not be processed
+			}), nil
+		},
+		listFn: func() ([]string, error) {
+			return []string{"auth"}, nil
+		},
+	}
+
+	cfg := &ScanConfig{
+		SearchValue: "123",
+		Keys:        []string{"user"},
+		Context:     2,
+		Limit:       1,
+	}
+
+	lp := NewLineProcessor(cfg, NewTimeParser())
+
+	var out, errOut bytes.Buffer
+
+	ds := NewDockerScanner(
+		lp,
+		mock,
+		&out,
+		&errOut,
+		time.Now(),
+	)
+
+	results, err := ds.Scan([]string{"auth"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(results) != 4 {
+		t.Fatalf("expected 4 results, got %d", len(results))
+	}
+
+	expected := []struct {
+		message   string
+		isContext bool
+	}{
+		{
+			message:   "user=ignore",
+			isContext: true,
+		},
+		{
+			message:   "user=123",
+			isContext: false,
+		},
+		{
+			message:   "user=ignore",
+			isContext: true,
+		},
+		{
+			message:   "user=ignore",
+			isContext: true,
+		},
+	}
+
+	for i, exp := range expected {
+		if results[i].Message != exp.message {
+			t.Fatalf(
+				"result[%d]: expected message %q, got %q",
+				i,
+				exp.message,
+				results[i].Message,
+			)
+		}
+
+		if results[i].IsContext != exp.isContext {
+			t.Fatalf(
+				"result[%d]: expected IsContext=%v, got %v",
+				i,
+				exp.isContext,
+				results[i].IsContext,
+			)
+		}
+	}
+}
+
 func TestDockerScanner_ListSources(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/internal/scanner/docker_scanner_test.go
+++ b/internal/scanner/docker_scanner_test.go
@@ -22,7 +22,7 @@ func dockerLogs(lines []string) io.ReadCloser {
 	return io.NopCloser(strings.NewReader(strings.Join(lines, "\n")))
 }
 
-func newTestDockerScanner(cfg *ScanConfig, client docker.DockerClient) *DockerScanner {
+func newTestDockerScanner(cfg *Config, client docker.DockerClient) *DockerScanner {
 	lp := NewLineProcessor(cfg, NewTimeParser())
 	return NewDockerScanner(lp, client, io.Discard, io.Discard, time.Now())
 }
@@ -35,7 +35,7 @@ func TestDockerScanner_Scan(t *testing.T) {
 	tests := []struct {
 		name       string
 		logsFn     func(container string, follow bool, since string) (io.ReadCloser, error)
-		cfg        *ScanConfig
+		cfg        *Config
 		containers []string
 		want       int
 		wantErrLog string
@@ -49,7 +49,7 @@ func TestDockerScanner_Scan(t *testing.T) {
 					"2024-03-10T12:02:00Z user=123 status=ok",
 				}), nil
 			},
-			cfg:        &ScanConfig{SearchValue: "123", Keys: []string{"user"}},
+			cfg:        &Config{SearchValue: "123", Keys: []string{"user"}},
 			containers: []string{"auth"},
 			want:       2,
 		},
@@ -61,7 +61,7 @@ func TestDockerScanner_Scan(t *testing.T) {
 					newTime + " user=123",
 				}), nil
 			},
-			cfg:        &ScanConfig{SearchValue: "123", Keys: []string{"user"}, Since: "5m"},
+			cfg:        &Config{SearchValue: "123", Keys: []string{"user"}, Since: "5m"},
 			containers: []string{"svc"},
 			want:       1,
 		},
@@ -70,7 +70,7 @@ func TestDockerScanner_Scan(t *testing.T) {
 			logsFn: func(container string, follow bool, since string) (io.ReadCloser, error) {
 				return dockerLogs([]string{"2024-03-10T12:00:00Z user=ABC"}), nil
 			},
-			cfg:        &ScanConfig{SearchValue: "abc", Keys: []string{"user"}, IgnoreCase: true},
+			cfg:        &Config{SearchValue: "abc", Keys: []string{"user"}, IgnoreCase: true},
 			containers: []string{"svc"},
 			want:       1,
 		},
@@ -79,7 +79,7 @@ func TestDockerScanner_Scan(t *testing.T) {
 			logsFn: func(container string, follow bool, since string) (io.ReadCloser, error) {
 				return dockerLogs([]string{"2024-03-10T12:00:00Z id=123", "2024-03-10T12:00:00Z id=123", "2024-03-10T12:00:00Z id=123"}), nil
 			},
-			cfg:        &ScanConfig{SearchValue: "123", Keys: []string{"id"}, Limit: 2},
+			cfg:        &Config{SearchValue: "123", Keys: []string{"id"}, Limit: 2},
 			containers: []string{"a", "b"},
 			want:       2,
 		},
@@ -91,7 +91,7 @@ func TestDockerScanner_Scan(t *testing.T) {
 				}
 				return dockerLogs([]string{"2024-03-10T12:00:00Z id=123"}), nil
 			},
-			cfg:        &ScanConfig{SearchValue: "123", Keys: []string{"id"}},
+			cfg:        &Config{SearchValue: "123", Keys: []string{"id"}},
 			containers: []string{"good", "bad"},
 			want:       1,
 		},
@@ -100,7 +100,7 @@ func TestDockerScanner_Scan(t *testing.T) {
 			logsFn: func(container string, follow bool, since string) (io.ReadCloser, error) {
 				return nil, fmt.Errorf("docker scan error")
 			},
-			cfg:        &ScanConfig{SearchValue: "123", Keys: []string{"user"}},
+			cfg:        &Config{SearchValue: "123", Keys: []string{"user"}},
 			containers: []string{"auth"},
 			want:       0,
 			wantErrLog: "docker scan error",
@@ -136,7 +136,7 @@ func TestDockerScanner_Scan(t *testing.T) {
 }
 
 func TestDockerScanner_Scan_InvalidSince(t *testing.T) {
-	cfg := &ScanConfig{
+	cfg := &Config{
 		SearchValue: "abc",
 		Keys:        []string{"user"},
 		IgnoreCase:  true,
@@ -196,7 +196,7 @@ func TestDockerScanner_Scan_JSON(t *testing.T) {
 				},
 			}
 
-			cfg := &ScanConfig{
+			cfg := &Config{
 				SearchValue: "123",
 				Keys:        []string{"user"},
 				JSONMode:    true,
@@ -245,7 +245,7 @@ func TestDockerScanner_Scan_Latest(t *testing.T) {
 		},
 	}
 
-	cfg := &ScanConfig{
+	cfg := &Config{
 		SearchValue: "123",
 		Keys:        []string{"id"},
 		Limit:       2,
@@ -304,7 +304,7 @@ func TestDockerScanner_Scan_Context(t *testing.T) {
 		},
 	}
 
-	cfg := &ScanConfig{
+	cfg := &Config{
 		SearchValue: "123",
 		Keys:        []string{"user"},
 		Context:     2,
@@ -410,7 +410,7 @@ func TestDockerScanner_ListSources(t *testing.T) {
 				},
 			}
 
-			cfg := &ScanConfig{
+			cfg := &Config{
 				Services: tt.services,
 			}
 
@@ -437,7 +437,7 @@ func TestDockerScanner_ListSources_Error(t *testing.T) {
 			return nil, errors.New("list error")
 		},
 	}
-	ds := newTestDockerScanner(&ScanConfig{}, mock)
+	ds := newTestDockerScanner(&Config{}, mock)
 
 	_, err := ds.ListSources()
 	if err == nil {
@@ -446,7 +446,7 @@ func TestDockerScanner_ListSources_Error(t *testing.T) {
 }
 
 func TestDockerScanner_Follow(t *testing.T) {
-	cfg := &ScanConfig{
+	cfg := &Config{
 		SearchValue: "123",
 		Keys:        []string{"user"},
 	}
@@ -534,7 +534,7 @@ func TestDockerScanner_Follow(t *testing.T) {
 }
 
 func TestDockerScanner_Follow_Errors(t *testing.T) {
-	cfg := &ScanConfig{
+	cfg := &Config{
 		SearchValue: "123",
 		Keys:        []string{"user"},
 	}

--- a/internal/scanner/entry_collector.go
+++ b/internal/scanner/entry_collector.go
@@ -76,17 +76,42 @@ func (c *EntryCollector) Add(entry *domain.LogEntry) bool {
 	return c.sourceCount < c.cfg.Limit
 }
 
+func (c *EntryCollector) AddContext(entry *domain.LogEntry) {
+	c.results = append(c.results, *entry)
+}
+
 func (c *EntryCollector) Results() []domain.LogEntry {
 	if c.cfg.Limit > 0 && c.cfg.Latest {
 		c.results = drainHeap(&c.heap)
 	}
 
-	sort.Slice(c.results, func(i, j int) bool {
+	sort.SliceStable(c.results, func(i, j int) bool {
 		return c.results[i].Timestamp.Before(c.results[j].Timestamp)
 	})
 
-	if c.cfg.Limit > 0 && !c.cfg.Latest && len(c.results) > c.cfg.Limit {
-		c.results = c.results[len(c.results)-c.cfg.Limit:]
+	if c.cfg.Limit > 0 {
+		res := make([]domain.LogEntry, 0, c.cfg.Limit)
+		matchedCount := 0
+		allowContext := true
+
+		for _, e := range c.results {
+			if e.IsContext {
+				if allowContext {
+					res = append(res, e)
+				}
+				continue
+			}
+
+			if matchedCount < c.cfg.Limit {
+				res = append(res, e)
+				matchedCount++
+				continue
+			}
+
+			allowContext = false
+		}
+
+		return res
 	}
 
 	return c.results

--- a/internal/scanner/entry_collector.go
+++ b/internal/scanner/entry_collector.go
@@ -9,7 +9,7 @@ import (
 )
 
 type EntryCollector struct {
-	cfg       *ScanConfig
+	cfg       *Config
 	sinceTime time.Time
 	results   []domain.LogEntry
 	heap      entryHeap
@@ -17,7 +17,7 @@ type EntryCollector struct {
 	sourceCount int
 }
 
-func NewEntryCollector(cfg *ScanConfig, now time.Time) (*EntryCollector, error) {
+func NewEntryCollector(cfg *Config, now time.Time) (*EntryCollector, error) {
 	sinceTime, err := parseSince(cfg.Since, now)
 	if err != nil {
 		return nil, err

--- a/internal/scanner/entry_collector_test.go
+++ b/internal/scanner/entry_collector_test.go
@@ -31,18 +31,18 @@ func TestNewEntryCollector(t *testing.T) {
 
 	tests := []struct {
 		name      string
-		cfg       *ScanConfig
+		cfg       *Config
 		expectErr bool
 	}{
 		{
 			name: "valid without latest",
-			cfg: &ScanConfig{
+			cfg: &Config{
 				Limit: 10,
 			},
 		},
 		{
 			name: "invalid since",
-			cfg: &ScanConfig{
+			cfg: &Config{
 				Since: "invalid",
 			},
 			expectErr: true,
@@ -68,7 +68,7 @@ func TestNewEntryCollector(t *testing.T) {
 }
 
 func TestEntryCollector_Add_NoLimit(t *testing.T) {
-	cfg := &ScanConfig{
+	cfg := &Config{
 		Limit: 0,
 	}
 
@@ -102,7 +102,7 @@ func TestEntryCollector_Add_NoLimit(t *testing.T) {
 }
 
 func TestEntryCollector_Add_DefaultLimit(t *testing.T) {
-	cfg := &ScanConfig{
+	cfg := &Config{
 		Limit: 2,
 	}
 
@@ -151,7 +151,7 @@ func TestEntryCollector_Add_DefaultLimit(t *testing.T) {
 }
 
 func TestEntryCollector_Add_Latest(t *testing.T) {
-	cfg := &ScanConfig{
+	cfg := &Config{
 		Limit:  2,
 		Latest: true,
 	}
@@ -188,7 +188,7 @@ func TestEntryCollector_Add_Latest(t *testing.T) {
 func TestEntryCollector_Add_SinceFiltering(t *testing.T) {
 	now := time.Unix(100, 0)
 
-	cfg := &ScanConfig{
+	cfg := &Config{
 		Since: "10s",
 	}
 
@@ -213,7 +213,7 @@ func TestEntryCollector_Add_SinceFiltering(t *testing.T) {
 }
 
 func TestEntryCollector_Add_NilEntry(t *testing.T) {
-	c, err := NewEntryCollector(&ScanConfig{}, time.Now())
+	c, err := NewEntryCollector(&Config{}, time.Now())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -230,7 +230,7 @@ func TestEntryCollector_Add_NilEntry(t *testing.T) {
 }
 
 func TestEntryCollector_Results_Sorted(t *testing.T) {
-	c, err := NewEntryCollector(&ScanConfig{}, time.Now())
+	c, err := NewEntryCollector(&Config{}, time.Now())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -250,7 +250,7 @@ func TestEntryCollector_Results_Sorted(t *testing.T) {
 }
 
 func TestEntryCollector_Results_WithContextAndLimit(t *testing.T) {
-	cfg := &ScanConfig{
+	cfg := &Config{
 		Limit: 2,
 	}
 
@@ -315,7 +315,7 @@ func TestEntryCollector_Results_WithContextAndLimit(t *testing.T) {
 }
 
 func TestEntryCollector_AddContext(t *testing.T) {
-	c, err := NewEntryCollector(&ScanConfig{}, time.Now())
+	c, err := NewEntryCollector(&Config{}, time.Now())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/internal/scanner/entry_collector_test.go
+++ b/internal/scanner/entry_collector_test.go
@@ -1,6 +1,7 @@
 package scanner
 
 import (
+	"reflect"
 	"testing"
 	"time"
 
@@ -245,5 +246,99 @@ func TestEntryCollector_Results_Sorted(t *testing.T) {
 		if got[i] != expected[i] {
 			t.Fatalf("expected %v, got %v", expected, got)
 		}
+	}
+}
+
+func TestEntryCollector_Results_WithContextAndLimit(t *testing.T) {
+	cfg := &ScanConfig{
+		Limit: 2,
+	}
+
+	c, err := NewEntryCollector(cfg, time.Now())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	entries := []domain.LogEntry{
+		{
+			Timestamp: time.Unix(1, 0),
+			Message:   "context-before-1",
+			IsContext: true,
+		},
+		{
+			Timestamp: time.Unix(2, 0),
+			Message:   "match-1",
+		},
+		{
+			Timestamp: time.Unix(3, 0),
+			Message:   "context-between",
+			IsContext: true,
+		},
+		{
+			Timestamp: time.Unix(4, 0),
+			Message:   "match-2",
+		},
+		{
+			Timestamp: time.Unix(5, 0),
+			Message:   "context-after-limit",
+			IsContext: true,
+		},
+	}
+
+	for _, e := range entries {
+		if e.IsContext {
+			c.AddContext(&e)
+		} else {
+			c.Add(&e)
+		}
+	}
+
+	results := c.Results()
+
+	got := make([]string, 0, len(results))
+
+	for _, r := range results {
+		got = append(got, r.Message)
+	}
+
+	expected := []string{
+		"context-before-1",
+		"match-1",
+		"context-between",
+		"match-2",
+		"context-after-limit",
+	}
+
+	if !reflect.DeepEqual(got, expected) {
+		t.Fatalf("expected %v, got %v", expected, got)
+	}
+}
+
+func TestEntryCollector_AddContext(t *testing.T) {
+	c, err := NewEntryCollector(&ScanConfig{}, time.Now())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	entry := domain.LogEntry{
+		Timestamp: time.Unix(1, 0),
+		Message:   "context",
+		IsContext: true,
+	}
+
+	c.AddContext(&entry)
+
+	results := c.Results()
+
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+
+	if !results[0].IsContext {
+		t.Fatalf("expected context entry")
+	}
+
+	if results[0].Message != "context" {
+		t.Fatalf("unexpected message: %q", results[0].Message)
 	}
 }

--- a/internal/scanner/factory_test.go
+++ b/internal/scanner/factory_test.go
@@ -3,7 +3,7 @@ package scanner
 import "testing"
 
 func TestNewScanner(t *testing.T) {
-	cfg := &ScanConfig{}
+	cfg := &Config{}
 	lp := NewLineProcessor(cfg, NewTimeParser())
 
 	tests := []struct {

--- a/internal/scanner/file_scanner.go
+++ b/internal/scanner/file_scanner.go
@@ -25,6 +25,7 @@ type ScanConfig struct {
 	Services    []string
 	JSONMode    bool
 	Latest      bool
+	Context     int
 }
 
 type FileScanner struct {
@@ -76,6 +77,8 @@ func (fs *FileScanner) Scan(files []string) ([]domain.LogEntry, error) {
 			reader := bufio.NewReader(file)
 			var offset int64 = 0
 
+			engine := NewContextEngine(fs.lineProcessor, collector, cfg.Context)
+
 			for {
 				line, err := reader.ReadString('\n')
 
@@ -83,11 +86,12 @@ func (fs *FileScanner) Scan(files []string) ([]domain.LogEntry, error) {
 					offset += int64(len(line))
 
 					entry, ok := fs.lineProcessor.ProcessLine(line, service)
-					if !ok {
-						continue
-					}
-
-					continueReading := collector.Add(entry)
+					continueReading := engine.Handle(ContextLine{
+						Line:    line,
+						Service: service,
+						Entry:   entry,
+						IsMatch: ok,
+					})
 					if !continueReading {
 						break
 					}

--- a/internal/scanner/file_scanner.go
+++ b/internal/scanner/file_scanner.go
@@ -14,20 +14,6 @@ import (
 	"github.com/sagarmaheshwary/reqlog/internal/formatter"
 )
 
-type ScanConfig struct {
-	Dir         string
-	SearchValue string
-	IgnoreCase  bool
-	Keys        []string
-	Since       string
-	Limit       int
-	Recursive   bool
-	Services    []string
-	JSONMode    bool
-	Latest      bool
-	Context     int
-}
-
 type FileScanner struct {
 	offsets        map[string]int64
 	lineProcessor  *LineProcessor

--- a/internal/scanner/file_scanner_benchmark_test.go
+++ b/internal/scanner/file_scanner_benchmark_test.go
@@ -74,7 +74,7 @@ func BenchmarkScanDir_PlainText(b *testing.B) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		cfg := &ScanConfig{
+		cfg := &Config{
 			Dir:         dir,
 			SearchValue: "abc123",
 			IgnoreCase:  false,
@@ -107,7 +107,7 @@ func BenchmarkScanDir_JSON(b *testing.B) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		cfg := &ScanConfig{
+		cfg := &Config{
 			Dir:         dir,
 			SearchValue: "json-abc",
 			IgnoreCase:  false,

--- a/internal/scanner/file_scanner_test.go
+++ b/internal/scanner/file_scanner_test.go
@@ -403,6 +403,57 @@ func TestFileScanner_Scan_JSON(t *testing.T) {
 	}
 }
 
+func TestFileScanner_ContextWindow_BeforeAndAfter(t *testing.T) {
+	dir := t.TempDir()
+
+	file := filepath.Join(dir, "svc.log")
+
+	// Structure:
+	// lines 1-2 -> context before match
+	// line 3    -> match (triggers window)
+	// line 4-5  -> after-context (must be included)
+	// line 6    -> should NOT be processed (stop after context)
+	writeFile(t, file, []byte(
+		"2024-03-10T12:00:00Z user=ignore\n"+ // before
+			"2024-03-10T12:00:01Z user=123\n"+ // before
+			"2024-03-10T12:00:02Z user=123\n"+ // match
+			"2024-03-10T12:00:03Z user=ignore\n"+ // after-context
+			"2024-03-10T12:00:04Z user=ignore\n"+ // after-context
+			"2024-03-10T12:00:05Z user=123\n", // must NOT be processed
+	))
+
+	cfg := &ScanConfig{
+		SearchValue: "123",
+		Keys:        []string{"user"},
+		Context:     2,
+		Limit:       1,
+	}
+
+	fs := newTestFileScanner(cfg)
+
+	results, err := fs.Scan([]string{file})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got := make([]string, 0, len(results))
+	for _, r := range results {
+		got = append(got, r.Message)
+	}
+
+	expected := []string{
+		"user=ignore", // before buffer
+		"user=123",    // match 1
+
+		"user=123",    // match 2 (NOT context)
+		"user=ignore", // after-context of match 2
+	}
+
+	if !reflect.DeepEqual(got, expected) {
+		t.Fatalf("expected %v, got %v", expected, got)
+	}
+}
+
 func TestListSources(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/internal/scanner/file_scanner_test.go
+++ b/internal/scanner/file_scanner_test.go
@@ -13,7 +13,7 @@ import (
 	"time"
 )
 
-func newTestFileScanner(cfg *ScanConfig) *FileScanner {
+func newTestFileScanner(cfg *Config) *FileScanner {
 	lp := NewLineProcessor(cfg, NewTimeParser())
 	return NewFileScanner(lp, time.Second, io.Discard, io.Discard, time.Now())
 }
@@ -34,7 +34,7 @@ func TestFileScanner_Scan(t *testing.T) {
 `
 	writeFile(t, filepath.Join(dir, "auth.log"), []byte(logContent))
 
-	cfg := &ScanConfig{
+	cfg := &Config{
 		Dir:         dir,
 		SearchValue: "123",
 		IgnoreCase:  false,
@@ -75,7 +75,7 @@ func TestFileScanner_Scan_WithSince(t *testing.T) {
 		newTime + " user=123 status=ok\n"
 	writeFile(t, filepath.Join(dir, "svc.log"), []byte(logContent))
 
-	cfg := &ScanConfig{
+	cfg := &Config{
 		Dir:         dir,
 		SearchValue: "123",
 		Keys:        []string{"user"},
@@ -104,7 +104,7 @@ func TestFileScanner_Scan_IgnoreCase(t *testing.T) {
 	logContent := `2024-03-10T12:00:00Z user=ABC status=ok`
 	writeFile(t, filepath.Join(dir, "svc.log"), []byte(logContent))
 
-	cfg := &ScanConfig{
+	cfg := &Config{
 		Dir:         dir,
 		SearchValue: "abc",
 		Keys:        []string{"user"},
@@ -133,7 +133,7 @@ func TestFileScanner_Scan_IgnoresNonLogFiles(t *testing.T) {
 	writeFile(t, filepath.Join(dir, "file.txt"), []byte("test"))
 	writeFile(t, filepath.Join(dir, "app.log"), []byte("invalid line"))
 
-	cfg := &ScanConfig{
+	cfg := &Config{
 		Dir:         dir,
 		SearchValue: "123",
 		Keys:        []string{"user"},
@@ -173,7 +173,7 @@ func TestScan_MultiFile_Limit(t *testing.T) {
 2024-03-10T12:00:06Z id=123
 `))
 
-	cfg := &ScanConfig{
+	cfg := &Config{
 		SearchValue: "123",
 		Keys:        []string{"id"},
 		Limit:       2,
@@ -208,7 +208,7 @@ func TestScan_MultiFile_Latest(t *testing.T) {
 2024-03-10T12:00:06Z id=123
 `))
 
-	cfg := &ScanConfig{
+	cfg := &Config{
 		SearchValue: "123",
 		Keys:        []string{"id"},
 		Limit:       2,
@@ -256,7 +256,7 @@ func TestScan_SkipsFileErrors(t *testing.T) {
 
 	writeFile(t, valid, []byte("2024-03-10T12:00:00Z id=123\n"))
 
-	cfg := &ScanConfig{
+	cfg := &Config{
 		SearchValue: "123",
 		Keys:        []string{"id"},
 	}
@@ -278,7 +278,7 @@ func TestScan_NoTrailingNewline(t *testing.T) {
 	file := filepath.Join(dir, "a.log")
 	writeFile(t, file, []byte("2024-03-10T12:00:00Z id=123")) // no newline
 
-	cfg := &ScanConfig{
+	cfg := &Config{
 		SearchValue: "123",
 		Keys:        []string{"id"},
 	}
@@ -295,7 +295,7 @@ func TestScan_NoTrailingNewline(t *testing.T) {
 }
 
 func TestFileScanner_Scan_ErrorLogging(t *testing.T) {
-	cfg := &ScanConfig{
+	cfg := &Config{
 		SearchValue: "123",
 		Keys:        []string{"user"},
 	}
@@ -328,7 +328,7 @@ func TestFileScanner_Scan_InvalidSince(t *testing.T) {
 	logContent := `2024-03-10T12:00:00Z user=ABC status=ok`
 	writeFile(t, filepath.Join(dir, "svc.log"), []byte(logContent))
 
-	cfg := &ScanConfig{
+	cfg := &Config{
 		Dir:         dir,
 		SearchValue: "abc",
 		Keys:        []string{"user"},
@@ -376,7 +376,7 @@ func TestFileScanner_Scan_JSON(t *testing.T) {
 			content := strings.Join(tt.logLines, "\n")
 			writeFile(t, filepath.Join(dir, "svc.log"), []byte(content))
 
-			cfg := &ScanConfig{
+			cfg := &Config{
 				Dir:         dir,
 				SearchValue: "123",
 				Keys:        []string{"user"},
@@ -422,7 +422,7 @@ func TestFileScanner_ContextWindow_BeforeAndAfter(t *testing.T) {
 			"2024-03-10T12:00:05Z user=123\n", // must NOT be processed
 	))
 
-	cfg := &ScanConfig{
+	cfg := &Config{
 		SearchValue: "123",
 		Keys:        []string{"user"},
 		Context:     2,
@@ -458,7 +458,7 @@ func TestListSources(t *testing.T) {
 	tests := []struct {
 		name      string
 		setup     func(dir string)
-		cfg       *ScanConfig
+		cfg       *Config
 		wantFiles func(dir string) []string
 	}{
 		{
@@ -470,7 +470,7 @@ func TestListSources(t *testing.T) {
 				os.Mkdir(filepath.Join(dir, "sub-dir"), 0755)
 				writeFile(t, filepath.Join(dir, "sub-dir", "svc.log"), []byte(""))
 			},
-			cfg: &ScanConfig{
+			cfg: &Config{
 				Services: []string{},
 			},
 			wantFiles: func(dir string) []string {
@@ -487,7 +487,7 @@ func TestListSources(t *testing.T) {
 				writeFile(t, filepath.Join(dir, "sub-dir", "svc.log"), []byte(""))
 				writeFile(t, filepath.Join(dir, "sub-dir", "non-log-file"), []byte(""))
 			},
-			cfg: &ScanConfig{
+			cfg: &Config{
 				Services:  []string{"svc"},
 				Recursive: true,
 			},
@@ -501,7 +501,7 @@ func TestListSources(t *testing.T) {
 				writeFile(t, filepath.Join(dir, "auth.log"), []byte(""))
 				writeFile(t, filepath.Join(dir, "db.log"), []byte(""))
 			},
-			cfg: &ScanConfig{
+			cfg: &Config{
 				Services: []string{"auth", " "}, //skip empty strings
 			},
 			wantFiles: func(dir string) []string {
@@ -514,7 +514,7 @@ func TestListSources(t *testing.T) {
 				writeFile(t, filepath.Join(dir, "svc.log"), []byte(""))
 				writeFile(t, filepath.Join(dir, "svc-1.log"), []byte(""))
 			},
-			cfg: &ScanConfig{
+			cfg: &Config{
 				Services:  []string{"svc*"},
 				Recursive: true,
 			},
@@ -607,7 +607,7 @@ func TestFileScanner_Follow(t *testing.T) {
 
 			var out bytes.Buffer
 
-			cfg := &ScanConfig{SearchValue: "123", Keys: []string{"user"}}
+			cfg := &Config{SearchValue: "123", Keys: []string{"user"}}
 			lp := NewLineProcessor(cfg, NewTimeParser())
 			fs := NewFileScanner(lp, 10*time.Millisecond, &out, io.Discard, time.Now())
 
@@ -643,7 +643,7 @@ func TestFileScanner_Follow(t *testing.T) {
 }
 
 func TestFileScanner_Follow_Errors(t *testing.T) {
-	cfg := &ScanConfig{
+	cfg := &Config{
 		SearchValue: "123",
 		Keys:        []string{"user"},
 	}

--- a/internal/scanner/line_processor.go
+++ b/internal/scanner/line_processor.go
@@ -38,23 +38,39 @@ func (lp *LineProcessor) ProcessLine(line, service string) (*domain.LogEntry, bo
 	}
 
 	if lp.config.JSONMode {
-		return lp.processJSONLine(line, service)
+		return lp.processJSONLine(line, service, false)
 	}
 
-	line = strings.TrimRight(line, "\r\n")
-	return lp.processTextLine(line, service)
+	return lp.processTextLine(
+		strings.TrimRight(line, "\r\n"),
+		service,
+		false,
+	)
 }
 
-func (lp *LineProcessor) processJSONLine(line string, service string) (*domain.LogEntry, bool) {
+func (lp *LineProcessor) ParseOnly(line, service string) (*domain.LogEntry, bool) {
+	if lp.config.JSONMode {
+		return lp.processJSONLine(line, service, true)
+	}
+	return lp.processTextLine(
+		strings.TrimRight(line, "\r\n"),
+		service,
+		true,
+	)
+}
+
+func (lp *LineProcessor) processJSONLine(line string, service string, skipMatch bool) (*domain.LogEntry, bool) {
 	if !gjson.Valid(line) {
 		return nil, false
 	}
 	obj := gjson.Parse(line)
 
-	foundID, ok := extractJSONField(obj, lp.config.Keys)
-	if !ok || !match(foundID, lp.config.SearchValue, lp.config.IgnoreCase) {
+	if !skipMatch {
+		foundID, ok := extractJSONField(obj, lp.config.Keys)
+		if !ok || !match(foundID, lp.config.SearchValue, lp.config.IgnoreCase) {
 
-		return nil, false
+			return nil, false
+		}
 	}
 
 	tsKey, tsVal, ok := lp.extractJSONTimestampValue(obj, service)
@@ -73,15 +89,17 @@ func (lp *LineProcessor) processJSONLine(line string, service string) (*domain.L
 	}, true
 }
 
-func (lp *LineProcessor) processTextLine(line string, service string) (*domain.LogEntry, bool) {
+func (lp *LineProcessor) processTextLine(line string, service string, skipMatch bool) (*domain.LogEntry, bool) {
 	parts := strings.Fields(line)
 	if len(parts) < 2 {
 		return nil, false
 	}
 
-	foundID, ok := extractTextField(parts, lp.config.Keys)
-	if !ok || !match(foundID, lp.config.SearchValue, lp.config.IgnoreCase) {
-		return nil, false
+	if !skipMatch {
+		foundID, ok := extractTextField(parts, lp.config.Keys)
+		if !ok || !match(foundID, lp.config.SearchValue, lp.config.IgnoreCase) {
+			return nil, false
+		}
 	}
 
 	ts, ok := lp.timeParser.Parse(parts[0], service)

--- a/internal/scanner/line_processor.go
+++ b/internal/scanner/line_processor.go
@@ -10,13 +10,13 @@ import (
 )
 
 type LineProcessor struct {
-	config        *ScanConfig
+	config        *Config
 	timeParser    TimeParser
 	mu            sync.RWMutex
 	timestampKeys map[string]string
 }
 
-func NewLineProcessor(cfg *ScanConfig, tp TimeParser) *LineProcessor {
+func NewLineProcessor(cfg *Config, tp TimeParser) *LineProcessor {
 	return &LineProcessor{
 		config:        cfg,
 		timeParser:    tp,

--- a/internal/scanner/line_processor_test.go
+++ b/internal/scanner/line_processor_test.go
@@ -186,6 +186,118 @@ func TestLineProcessor_ProcessLine_JSONMode(t *testing.T) {
 	}
 }
 
+func TestLineProcessor_ParseOnly(t *testing.T) {
+	tests := []struct {
+		name      string
+		cfg       *ScanConfig
+		line      string
+		service   string
+		wantOK    bool
+		wantMsg   string
+		wantSvc   string
+		wantIsNil bool
+	}{
+		{
+			name:    "valid text log",
+			cfg:     &ScanConfig{},
+			line:    "2024-03-10T12:00:00Z user=999 status=ok",
+			service: "auth",
+			wantOK:  true,
+			wantMsg: "user=999 status=ok",
+			wantSvc: "auth",
+		},
+		{
+			name:      "invalid timestamp",
+			cfg:       &ScanConfig{},
+			line:      "invalid user=123",
+			service:   "auth",
+			wantOK:    false,
+			wantIsNil: true,
+		},
+		{
+			name:      "missing key=value field",
+			cfg:       &ScanConfig{},
+			line:      "2024-03-10T12:00:00Z",
+			service:   "auth",
+			wantOK:    false,
+			wantIsNil: true,
+		},
+		{
+			name: "valid json log",
+			cfg: &ScanConfig{
+				JSONMode: true,
+			},
+			line:    `{"time":"2024-03-10T12:00:00Z","user":"999","status":"ok"}`,
+			service: "api",
+			wantOK:  true,
+			wantSvc: "api",
+		},
+		{
+			name: "invalid json log",
+			cfg: &ScanConfig{
+				JSONMode: true,
+			},
+			line:      `{"time":"2024-03-10T12:00:00Z"`,
+			service:   "api",
+			wantOK:    false,
+			wantIsNil: true,
+		},
+		{
+			name: "json missing timestamp",
+			cfg: &ScanConfig{
+				JSONMode: true,
+			},
+			line:      `{"user":"123"}`,
+			service:   "api",
+			wantOK:    false,
+			wantIsNil: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lp := NewLineProcessor(tt.cfg, NewTimeParser())
+
+			entry, ok := lp.ParseOnly(tt.line, tt.service)
+
+			if ok != tt.wantOK {
+				t.Fatalf("expected ok=%v, got %v", tt.wantOK, ok)
+			}
+
+			if tt.wantIsNil {
+				if entry != nil {
+					t.Fatalf("expected nil entry, got %+v", entry)
+				}
+				return
+			}
+
+			if entry == nil {
+				t.Fatal("expected non-nil entry")
+			}
+
+			if tt.wantMsg != "" && entry.Message != tt.wantMsg {
+				t.Fatalf(
+					"expected message %q, got %q",
+					tt.wantMsg,
+					entry.Message,
+				)
+			}
+
+			if entry.Service != tt.wantSvc {
+				t.Fatalf(
+					"expected service %q, got %q",
+					tt.wantSvc,
+					entry.Service,
+				)
+			}
+
+			if entry.Timestamp.IsZero() {
+				t.Fatal("expected non-zero timestamp")
+			}
+		})
+	}
+}
+
 func TestLineProcessor_JSONTimestampKeyCaching(t *testing.T) {
 	tp := NewTimeParser()
 

--- a/internal/scanner/line_processor_test.go
+++ b/internal/scanner/line_processor_test.go
@@ -65,7 +65,7 @@ func TestLineProcessor_ProcessLine_TextMode(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cfg := &ScanConfig{
+			cfg := &Config{
 				SearchValue: tt.searchValue,
 				IgnoreCase:  tt.ignoreCase,
 				Keys:        tt.keys,
@@ -162,7 +162,7 @@ func TestLineProcessor_ProcessLine_JSONMode(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cfg := &ScanConfig{
+			cfg := &Config{
 				SearchValue: tt.searchValue,
 				IgnoreCase:  tt.ignoreCase,
 				Keys:        tt.keys,
@@ -189,7 +189,7 @@ func TestLineProcessor_ProcessLine_JSONMode(t *testing.T) {
 func TestLineProcessor_ParseOnly(t *testing.T) {
 	tests := []struct {
 		name      string
-		cfg       *ScanConfig
+		cfg       *Config
 		line      string
 		service   string
 		wantOK    bool
@@ -199,7 +199,7 @@ func TestLineProcessor_ParseOnly(t *testing.T) {
 	}{
 		{
 			name:    "valid text log",
-			cfg:     &ScanConfig{},
+			cfg:     &Config{},
 			line:    "2024-03-10T12:00:00Z user=999 status=ok",
 			service: "auth",
 			wantOK:  true,
@@ -208,7 +208,7 @@ func TestLineProcessor_ParseOnly(t *testing.T) {
 		},
 		{
 			name:      "invalid timestamp",
-			cfg:       &ScanConfig{},
+			cfg:       &Config{},
 			line:      "invalid user=123",
 			service:   "auth",
 			wantOK:    false,
@@ -216,7 +216,7 @@ func TestLineProcessor_ParseOnly(t *testing.T) {
 		},
 		{
 			name:      "missing key=value field",
-			cfg:       &ScanConfig{},
+			cfg:       &Config{},
 			line:      "2024-03-10T12:00:00Z",
 			service:   "auth",
 			wantOK:    false,
@@ -224,7 +224,7 @@ func TestLineProcessor_ParseOnly(t *testing.T) {
 		},
 		{
 			name: "valid json log",
-			cfg: &ScanConfig{
+			cfg: &Config{
 				JSONMode: true,
 			},
 			line:    `{"time":"2024-03-10T12:00:00Z","user":"999","status":"ok"}`,
@@ -234,7 +234,7 @@ func TestLineProcessor_ParseOnly(t *testing.T) {
 		},
 		{
 			name: "invalid json log",
-			cfg: &ScanConfig{
+			cfg: &Config{
 				JSONMode: true,
 			},
 			line:      `{"time":"2024-03-10T12:00:00Z"`,
@@ -244,7 +244,7 @@ func TestLineProcessor_ParseOnly(t *testing.T) {
 		},
 		{
 			name: "json missing timestamp",
-			cfg: &ScanConfig{
+			cfg: &Config{
 				JSONMode: true,
 			},
 			line:      `{"user":"123"}`,
@@ -301,7 +301,7 @@ func TestLineProcessor_ParseOnly(t *testing.T) {
 func TestLineProcessor_JSONTimestampKeyCaching(t *testing.T) {
 	tp := NewTimeParser()
 
-	cfg := &ScanConfig{
+	cfg := &Config{
 		SearchValue: "abc",
 		Keys:        []string{"request_id"},
 		JSONMode:    true,

--- a/internal/scanner/ring_buffer.go
+++ b/internal/scanner/ring_buffer.go
@@ -1,0 +1,45 @@
+package scanner
+
+import "github.com/sagarmaheshwary/reqlog/internal/domain"
+
+type ringBuffer struct {
+	buf  []domain.LogEntry
+	head int
+	size int
+	cap  int
+}
+
+func NewRingBuffer(capacity int) *ringBuffer {
+	return &ringBuffer{
+		buf: make([]domain.LogEntry, capacity),
+		cap: capacity,
+	}
+}
+
+func (r *ringBuffer) Push(line domain.LogEntry) {
+	if r.cap == 0 {
+		return
+	}
+	if r.size < r.cap {
+		// buf[head..head+size) are valid; write at head+size
+		r.buf[(r.head+r.size)%r.cap] = line
+		r.size++
+	} else {
+		// full: overwrite oldest slot, advance head
+		r.buf[r.head] = line
+		r.head = (r.head + 1) % r.cap
+	}
+}
+
+func (r *ringBuffer) Drain() []domain.LogEntry {
+	if r.size == 0 {
+		return nil
+	}
+	out := make([]domain.LogEntry, r.size)
+	for i := 0; i < r.size; i++ {
+		out[i] = r.buf[(r.head+i)%r.cap]
+	}
+	r.head = 0
+	r.size = 0
+	return out
+}

--- a/internal/scanner/ring_buffer_test.go
+++ b/internal/scanner/ring_buffer_test.go
@@ -1,0 +1,139 @@
+package scanner
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/sagarmaheshwary/reqlog/internal/domain"
+)
+
+func rbEntry(id int) domain.LogEntry {
+	return domain.LogEntry{
+		Message: fmt.Sprintf("msg-%d", id),
+	}
+}
+
+func rbMessages(entries []domain.LogEntry) []string {
+	out := make([]string, 0, len(entries))
+
+	for _, e := range entries {
+		out = append(out, e.Message)
+	}
+
+	return out
+}
+
+func TestRingBuffer(t *testing.T) {
+	tests := []struct {
+		name     string
+		capacity int
+		pushes   []int
+		expected []string
+	}{
+		{
+			name:     "zero capacity",
+			capacity: 0,
+			pushes:   []int{1, 2, 3},
+			expected: []string{},
+		},
+		{
+			name:     "single entry",
+			capacity: 3,
+			pushes:   []int{1},
+			expected: []string{"msg-1"},
+		},
+		{
+			name:     "under capacity",
+			capacity: 3,
+			pushes:   []int{1, 2},
+			expected: []string{"msg-1", "msg-2"},
+		},
+		{
+			name:     "exact capacity",
+			capacity: 3,
+			pushes:   []int{1, 2, 3},
+			expected: []string{"msg-1", "msg-2", "msg-3"},
+		},
+		{
+			name:     "overwrite oldest once full",
+			capacity: 3,
+			pushes:   []int{1, 2, 3, 4},
+			expected: []string{"msg-2", "msg-3", "msg-4"},
+		},
+		{
+			name:     "multiple wraparounds",
+			capacity: 3,
+			pushes:   []int{1, 2, 3, 4, 5, 6},
+			expected: []string{"msg-4", "msg-5", "msg-6"},
+		},
+		{
+			name:     "capacity one",
+			capacity: 1,
+			pushes:   []int{1, 2, 3},
+			expected: []string{"msg-3"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rb := NewRingBuffer(tt.capacity)
+
+			for _, id := range tt.pushes {
+				rb.Push(rbEntry(id))
+			}
+
+			got := rbMessages(rb.Drain())
+
+			if !reflect.DeepEqual(got, tt.expected) {
+				t.Fatalf("expected %v, got %v", tt.expected, got)
+			}
+		})
+	}
+}
+
+func TestRingBuffer_DrainResetsBuffer(t *testing.T) {
+	rb := NewRingBuffer(3)
+
+	rb.Push(rbEntry(1))
+	rb.Push(rbEntry(2))
+
+	first := rbMessages(rb.Drain())
+
+	expectedFirst := []string{"msg-1", "msg-2"}
+
+	if !reflect.DeepEqual(first, expectedFirst) {
+		t.Fatalf("expected %v, got %v", expectedFirst, first)
+	}
+
+	second := rb.Drain()
+
+	if second != nil {
+		t.Fatalf("expected nil after draining empty buffer, got %v", second)
+	}
+}
+
+func TestRingBuffer_MultipleDrainCycles(t *testing.T) {
+	rb := NewRingBuffer(2)
+
+	rb.Push(rbEntry(1))
+	rb.Push(rbEntry(2))
+
+	got1 := rbMessages(rb.Drain())
+
+	expected1 := []string{"msg-1", "msg-2"}
+
+	if !reflect.DeepEqual(got1, expected1) {
+		t.Fatalf("expected %v, got %v", expected1, got1)
+	}
+
+	rb.Push(rbEntry(3))
+
+	got2 := rbMessages(rb.Drain())
+
+	expected2 := []string{"msg-3"}
+
+	if !reflect.DeepEqual(got2, expected2) {
+		t.Fatalf("expected %v, got %v", expected2, got2)
+	}
+}


### PR DESCRIPTION
## Summary

This PR introduces grep-style context support for log tracing and improves scanner structure to support reusable context handling across multiple sources.

## Features

### --context flag

Adds support for displaying N lines before and after each matched log line.

Example:

```
reqlog --service order --context 2
```

Output:

```
[line-2 before]
[line-1 before]
MATCH
[line+1 after]
[line+2 after]
```

### Key behavior:

- preserves before-context using a rolling buffer
- emits after-context following each match
- correctly handles overlapping matches without duplication
- works across both file and docker log sources
- context lines are visually dimmed in output

## Internal changes

### Context system

- introduced `BufferRing` to efficiently store rolling context lines
- added `ContextEngine` to centralize context logic across scanners
- integrated context handling into both `FileScanner` and `DockerScanner`
- ensures reusable and consistent behavior across sources

### Refactor

- renamed `ScanConfig` → `Config`
- moved configuration into `internal/scanner/config.go`
- improved separation of concerns between scanners and config

## Testing

Added test coverage for:

- FileScanner context behavior
- DockerScanner context behavior
- BufferRing correctness
- ContextEngine logic
- output formatter changes (dimmed context lines)

## Notes

This implementation follows a streaming approach and avoids loading full logs into memory, ensuring good performance even for large files and container logs.
