### PR TITLE
Add --output=json support for structured log output

### DIFF
--- a/cmd/reqlog/main.go
+++ b/cmd/reqlog/main.go
@@ -26,9 +26,10 @@ var (
 	since       = flag.String("since", "", "filter logs newer than: duration (5m, 1h), RFC3339 timestamp, or YYYY-MM-DD (UTC)")
 	recursive   = flag.Bool("recursive", true, "scan directories recursively")
 	service     = flag.String("service", "", "filter by service name (comma-separated, e.g. order-service,inventory-service)")
-	source      = flag.String("source", "file", `log source backend: "file", "docker"`)
+	source      = flag.String("source", "file", `log source backend ("file" or "docker")`)
 	versionFlag = flag.Bool("version", false, "print version and exit")
 	contextFlag = flag.Int("context", 0, "show N lines of context before and after each match")
+	output      = flag.String("output", "pretty", `output format ("pretty" or "json")`)
 )
 
 var version = "dev"
@@ -143,7 +144,7 @@ func main() {
 		log.Fatal(err)
 	}
 
-	f := formatter.NewFormatter(entries, keys)
+	f := formatter.NewFormatter(entries, keys, formatter.OutputFormat(*output))
 
 	printEntries(f, entries)
 

--- a/internal/domain/logentry.go
+++ b/internal/domain/logentry.go
@@ -7,4 +7,6 @@ type LogEntry struct {
 	Service   string
 	Message   string
 	IsContext bool
+	Fields    map[string]any
+	Raw       string
 }

--- a/internal/formatter/formatter.go
+++ b/internal/formatter/formatter.go
@@ -1,23 +1,33 @@
 package formatter
 
 import (
+	"encoding/json"
 	"fmt"
 	"slices"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/sagarmaheshwary/reqlog/internal/domain"
 )
 
 var tsFormat = "2006-01-02T15:04:05.000Z07:00"
 
+type OutputFormat string
+
+const (
+	OutputPretty OutputFormat = "pretty"
+	OutputJSON   OutputFormat = "json"
+)
+
 type Formatter struct {
 	colorizer    *Colorizer
 	serviceWidth int
 	searchKeys   []string
+	output       OutputFormat
 }
 
-func NewFormatter(entries []domain.LogEntry, searchKeys []string) *Formatter {
+func NewFormatter(entries []domain.LogEntry, searchKeys []string, output OutputFormat) *Formatter {
 	max := 0
 	for _, e := range entries {
 		if len(e.Service) > max {
@@ -29,6 +39,7 @@ func NewFormatter(entries []domain.LogEntry, searchKeys []string) *Formatter {
 		colorizer:    NewColorizer(),
 		serviceWidth: max,
 		searchKeys:   searchKeys,
+		output:       output,
 	}
 }
 
@@ -40,10 +51,56 @@ func (f *Formatter) padAfter(service string) string {
 }
 
 func (f *Formatter) Format(entry domain.LogEntry) string {
+	switch f.output {
+	case OutputJSON:
+		return f.outputJSON(entry)
+
+	case OutputPretty:
+		fallthrough
+
+	default:
+		return f.outputPretty(entry)
+	}
+}
+
+func (f *Formatter) outputJSON(entry domain.LogEntry) string {
+	out := make(map[string]any, len(entry.Fields)+5)
+
+	out["timestamp"] = entry.Timestamp.Format(time.RFC3339Nano)
+	out["service"] = entry.Service
+	out["message"] = entry.Message
+	out["context"] = entry.IsContext
+
+	for k, v := range entry.Fields {
+		// avoid accidental overwrite of core keys
+		switch k {
+		case "timestamp", "service", "message", "context":
+			out["fields."+k] = v
+		default:
+			out[k] = v
+		}
+	}
+
+	b, err := json.Marshal(out)
+	if err == nil {
+		return string(b)
+	}
+
+	errorOut := map[string]any{
+		"error":   "failed to marshal log entry",
+		"details": err.Error(),
+		"raw":     entry.Raw,
+	}
+
+	fallback, _ := json.Marshal(errorOut)
+	return string(fallback)
+}
+
+func (f *Formatter) outputPretty(entry domain.LogEntry) string {
 	serviceColor := f.colorizer.Color(entry.Service)
 	padding := f.padAfter(entry.Service)
 
-	msg := f.formatMessage(entry.Message)
+	msg := f.renderPrettyMessage(entry)
 
 	if entry.IsContext {
 		msg = dim + msg + reset
@@ -67,7 +124,50 @@ func (f *Formatter) Format(entry domain.LogEntry) string {
 	)
 }
 
-func (f *Formatter) colorLevel(val string) string {
+func (f *Formatter) renderPrettyMessage(entry domain.LogEntry) string {
+	fields := f.renderPrettyFields(entry.Fields)
+
+	if entry.Message == "" {
+		return fields
+	}
+
+	if fields == "" {
+		return entry.Message
+	}
+
+	return entry.Message + " " + fields
+}
+
+func (f *Formatter) renderPrettyFields(fields map[string]any) string {
+	var kvParts []string
+
+	for _, pair := range sortKVByPriority(fields) {
+		key := pair.key
+		val := pair.value
+
+		renderedVal := stringifyValue(val)
+
+		if key == "level" {
+			renderedVal = f.colorLevel(val)
+		}
+
+		key = f.highlightKey(key)
+
+		kvParts = append(
+			kvParts,
+			fmt.Sprintf(
+				"%s=%s",
+				f.colorizer.Cyan(key),
+				renderedVal,
+			),
+		)
+	}
+
+	return strings.Join(kvParts, " ")
+}
+
+func (f *Formatter) colorLevel(v any) string {
+	val := stringifyValue(v)
 	switch strings.ToLower(val) {
 	case "error":
 		return f.colorizer.Red(val)
@@ -85,116 +185,55 @@ func (f *Formatter) highlightKey(key string) string {
 	return key
 }
 
-func (f *Formatter) formatMessage(msg string) string {
-	mainMsg, pairs := parseMessage(msg)
-
-	var kvParts []string
-
-	for _, p := range pairs {
-		key := p.key
-		val := p.value
-
-		if key == "level" {
-			val = f.colorLevel(val)
-		}
-
-		key = f.highlightKey(key)
-
-		kvParts = append(kvParts,
-			fmt.Sprintf("%s=%s",
-				f.colorizer.Cyan(key),
-				val,
-			),
-		)
-	}
-
-	if len(kvParts) == 0 {
-		return mainMsg
-	}
-
-	if mainMsg == "" {
-		return fmt.Sprintf("%s", strings.Join(kvParts, ""))
-	}
-
-	return fmt.Sprintf("%s %s", mainMsg, strings.Join(kvParts, " "))
-}
-
 type kv struct {
 	key   string
-	value string
+	value any
 }
 
-func parseMessage(msg string) (string, []kv) {
-	parts := strings.Fields(msg)
+func sortKVByPriority(fields map[string]any) []kv {
+	pairs := make([]kv, 0, len(fields))
 
-	var pairs []kv
-	var messageParts []string
-
-	i := 0
-	for i < len(parts) {
-		part := parts[i]
-
-		if strings.Contains(part, "=") {
-			split := strings.SplitN(part, "=", 2)
-			key := split[0]
-			value := split[1]
-
-			j := i + 1
-			for j < len(parts) && !strings.Contains(parts[j], "=") {
-				value += " " + parts[j]
-				j++
-			}
-
-			pairs = append(pairs, kv{key, value})
-			i = j
-			continue
-		}
-
-		messageParts = append(messageParts, part)
-		i++
+	for k, v := range fields {
+		pairs = append(pairs, kv{
+			key:   k,
+			value: v,
+		})
 	}
 
-	var mainMsg string
-	filtered := make([]kv, 0, len(pairs))
-
-	for _, p := range pairs {
-		if p.key == "message" || p.key == "msg" {
-			mainMsg = p.value
-			continue
-		}
-		filtered = append(filtered, p)
-	}
-
-	if mainMsg == "" {
-		mainMsg = strings.Join(messageParts, " ")
-	}
-
-	filtered = sortKVByPriority(filtered)
-
-	return mainMsg, filtered
-}
-
-var keyPriority = map[string]int{
-	"level":      1,
-	"request_id": 2,
-}
-
-func sortKVByPriority(pairs []kv) []kv {
 	priority := func(key string) int {
-		if val, ok := keyPriority[key]; ok {
-			return val
+		switch key {
+		case "level":
+			return 1
+		case "request_id":
+			return 2
+		default:
+			return 99
 		}
-		return 99
 	}
 
 	sort.SliceStable(pairs, func(i, j int) bool {
 		pi := priority(pairs[i].key)
 		pj := priority(pairs[j].key)
+
 		if pi != pj {
 			return pi < pj
 		}
+
 		return pairs[i].key < pairs[j].key
 	})
 
 	return pairs
+}
+
+func stringifyValue(v any) string {
+	switch val := v.(type) {
+	case string:
+		return val
+
+	case nil:
+		return "null"
+
+	default:
+		return fmt.Sprintf("%v", val)
+	}
 }

--- a/internal/formatter/formatter_test.go
+++ b/internal/formatter/formatter_test.go
@@ -1,6 +1,7 @@
 package formatter
 
 import (
+	"encoding/json"
 	"reflect"
 	"strings"
 	"testing"
@@ -9,52 +10,22 @@ import (
 	"github.com/sagarmaheshwary/reqlog/internal/domain"
 )
 
-func TestParseMessage_RemovesMessageKey(t *testing.T) {
-	msg := "level=info message=Hello request_id=abc123 extra=xyz"
-	main, pairs := parseMessage(msg)
-
-	if main != "Hello" {
-		t.Fatalf("expected main message 'Hello', got %q", main)
-	}
-
-	for _, p := range pairs {
-		if p.key == "message" || p.key == "msg" {
-			t.Fatalf("message key should be removed from pairs")
-		}
-	}
-
-	if len(pairs) != 3 { // level, request_id, extra
-		t.Fatalf("expected 3 kv pairs, got %d", len(pairs))
-	}
-}
-
-func TestParseMessage_SortsByPriority(t *testing.T) {
-	msg := "extra=foo request_id=abc123 level=warn alpha=bar"
-	_, pairs := parseMessage(msg)
-
-	if pairs[0].key != "level" {
-		t.Fatalf("expected first key 'level', got %q", pairs[0].key)
-	}
-	if pairs[1].key != "request_id" {
-		t.Fatalf("expected second key 'request_id', got %q", pairs[1].key)
-	}
-	// rest are sorted alphabetically
-	if pairs[2].key != "alpha" || pairs[3].key != "extra" {
-		t.Fatalf("expected remaining keys sorted alphabetically, got %v", pairs[2:])
-	}
-}
-
 func TestFormat_HighlightSearchKey(t *testing.T) {
 	entry := domain.LogEntry{
 		Timestamp: time.Now(),
 		Service:   "api",
-		Message:   "request_id=abc123 level=info message=hello",
+		Message:   "hello",
+		Fields: map[string]any{
+			"request_id": "abc123",
+			"level":      "info",
+		},
 	}
 
 	f := &Formatter{
 		colorizer:    NewColorizer(),
 		searchKeys:   []string{"request_id"},
 		serviceWidth: len("api"),
+		output:       OutputPretty,
 	}
 
 	out := f.Format(entry)
@@ -69,7 +40,10 @@ func TestFormat_ColorLevel(t *testing.T) {
 	entry := domain.LogEntry{
 		Timestamp: time.Now(),
 		Service:   "api",
-		Message:   "level=error message=fail",
+		Message:   "fail",
+		Fields: map[string]any{
+			"level": "error",
+		},
 	}
 
 	f := &Formatter{
@@ -99,7 +73,7 @@ func TestFormat_OutputStructure(t *testing.T) {
 		{Service: "longer-service"},
 	}
 
-	f := NewFormatter(entries, []string{"request_id"})
+	f := NewFormatter(entries, []string{"request_id"}, OutputPretty)
 
 	out := f.Format(entry)
 
@@ -125,77 +99,18 @@ func TestFormat_OutputStructure(t *testing.T) {
 	}
 }
 
-func TestParseMessage(t *testing.T) {
-	tests := []struct {
-		name         string
-		input        string
-		wantMainMsg  string
-		wantKVKeys   []string
-		wantKVValues []string
-	}{
-		{
-			name:         "message key removed and main msg extracted",
-			input:        "level=info message=Hello request_id=abc123 extra=xyz",
-			wantMainMsg:  "Hello",
-			wantKVKeys:   []string{"level", "request_id", "extra"},
-			wantKVValues: []string{"info", "abc123", "xyz"},
-		},
-		{
-			name:         "no message key, text treated as main message",
-			input:        "just some log text level=warn",
-			wantMainMsg:  "just some log text",
-			wantKVKeys:   []string{"level"},
-			wantKVValues: []string{"warn"},
-		},
-		{
-			name:         "message key with spaces preserved",
-			input:        "message=Hello world level=info request_id=xyz",
-			wantMainMsg:  "Hello world",
-			wantKVKeys:   []string{"level", "request_id"},
-			wantKVValues: []string{"info", "xyz"},
-		},
-		{
-			name:         "multiline value handled",
-			input:        "time_taken=13ms message=hit level=info",
-			wantMainMsg:  "hit",
-			wantKVKeys:   []string{"level", "time_taken"},
-			wantKVValues: []string{"info", "13ms"},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			mainMsg, kvs := parseMessage(tt.input)
-
-			if mainMsg != tt.wantMainMsg {
-				t.Errorf("mainMsg = %q; want %q", mainMsg, tt.wantMainMsg)
-			}
-
-			if len(kvs) != len(tt.wantKVKeys) {
-				t.Fatalf("got %d kv pairs, want %d", len(kvs), len(tt.wantKVKeys))
-			}
-
-			for i, kv := range kvs {
-				if kv.key != tt.wantKVKeys[i] || kv.value != tt.wantKVValues[i] {
-					t.Errorf("kv[%d] = {%q, %q}; want {%q, %q}", i, kv.key, kv.value, tt.wantKVKeys[i], tt.wantKVValues[i])
-				}
-			}
-		})
-	}
-}
-
 func TestSortKVByPriority(t *testing.T) {
 	tests := []struct {
 		name     string
-		input    []kv
+		input    map[string]any
 		expected []kv
 	}{
 		{
 			name: "prioritizes level then request_id",
-			input: []kv{
-				{key: "extra", value: "foo"},
-				{key: "request_id", value: "abc"},
-				{key: "level", value: "warn"},
+			input: map[string]any{
+				"extra":      "foo",
+				"request_id": "abc",
+				"level":      "warn",
 			},
 			expected: []kv{
 				{key: "level", value: "warn"},
@@ -205,9 +120,9 @@ func TestSortKVByPriority(t *testing.T) {
 		},
 		{
 			name: "alphabetical fallback for equal priority",
-			input: []kv{
-				{key: "zeta", value: "1"},
-				{key: "alpha", value: "2"},
+			input: map[string]any{
+				"zeta":  "1",
+				"alpha": "2",
 			},
 			expected: []kv{
 				{key: "alpha", value: "2"},
@@ -216,13 +131,12 @@ func TestSortKVByPriority(t *testing.T) {
 		},
 		{
 			name: "mixed priority and alphabetical",
-			input: []kv{
-				{key: "beta", value: "b"},
-				{key: "level", value: "info"},
-				{key: "request_id", value: "r1"},
-				{key: "alpha", value: "a"},
-			},
-			expected: []kv{
+			input: map[string]any{
+				"beta":       "b",
+				"level":      "info",
+				"request_id": "r1",
+				"alpha":      "a",
+			}, expected: []kv{
 				{key: "level", value: "info"},
 				{key: "request_id", value: "r1"},
 				{key: "alpha", value: "a"},
@@ -242,7 +156,7 @@ func TestSortKVByPriority(t *testing.T) {
 }
 
 func TestFormatter_Format_ContextEntry(t *testing.T) {
-	f := NewFormatter(nil, nil)
+	f := NewFormatter(nil, nil, OutputPretty)
 
 	entry := domain.LogEntry{
 		Timestamp: mustParseTime(t, "2024-03-10T12:00:00Z"),
@@ -271,4 +185,171 @@ func mustParseTime(t *testing.T, s string) time.Time {
 	}
 
 	return ts
+}
+
+func TestFormatter_OutputJSON(t *testing.T) {
+	tests := []struct {
+		name   string
+		entry  domain.LogEntry
+		assert func(t *testing.T, m map[string]any)
+	}{
+		{
+			name: "basic json output",
+			entry: domain.LogEntry{
+				Timestamp: mustParseRFC3339("2024-03-10T12:00:00Z"),
+				Service:   "auth",
+				Message:   "login success",
+				Fields: map[string]any{
+					"user": "123",
+				},
+				IsContext: false,
+			},
+			assert: func(t *testing.T, m map[string]any) {
+				if m["service"] != "auth" {
+					t.Fatalf("service mismatch: %v", m["service"])
+				}
+				if m["message"] != "login success" {
+					t.Fatalf("message mismatch: %v", m["message"])
+				}
+				if m["user"] != "123" {
+					t.Fatalf("field user missing or wrong: %v", m["user"])
+				}
+			},
+		},
+
+		{
+			name: "context flag is included",
+			entry: domain.LogEntry{
+				Timestamp: mustParseRFC3339("2024-03-10T12:00:00Z"),
+				Service:   "auth",
+				Message:   "login",
+				IsContext: true,
+			},
+			assert: func(t *testing.T, m map[string]any) {
+				if m["context"] != true {
+					t.Fatalf("expected context=true, got %v", m["context"])
+				}
+			},
+		},
+
+		{
+			name: "reserved keys are prefixed into fields.*",
+			entry: domain.LogEntry{
+				Timestamp: mustParseRFC3339("2024-03-10T12:00:00Z"),
+				Service:   "auth",
+				Message:   "test",
+				Fields: map[string]any{
+					"timestamp": "override-ts",
+					"service":   "override-service",
+					"message":   "override-message",
+					"context":   "override-context",
+				},
+			},
+			assert: func(t *testing.T, m map[string]any) {
+				if m["timestamp"] == "override-ts" {
+					t.Fatalf("timestamp should NOT be overwritten")
+				}
+				if m["service"] == "override-service" {
+					t.Fatalf("service should NOT be overwritten")
+				}
+				if m["message"] == "override-message" {
+					t.Fatalf("message should NOT be overwritten")
+				}
+				if m["context"] == "override-context" {
+					t.Fatalf("context should NOT be overwritten")
+				}
+
+				if m["fields.timestamp"] != "override-ts" {
+					t.Fatalf("expected fields.timestamp, got %v", m["fields.timestamp"])
+				}
+			},
+		},
+
+		{
+			name: "multiple fields preserved",
+			entry: domain.LogEntry{
+				Timestamp: mustParseRFC3339("2024-03-10T12:00:00Z"),
+				Service:   "svc",
+				Message:   "ok",
+				Fields: map[string]any{
+					"a": 1,
+					"b": true,
+					"c": 1.5,
+				},
+			},
+			assert: func(t *testing.T, m map[string]any) {
+				if m["a"] != float64(1) && m["a"] != 1 {
+					t.Fatalf("unexpected a: %v", m["a"])
+				}
+				if m["b"] != true {
+					t.Fatalf("unexpected b: %v", m["b"])
+				}
+				if m["c"] != 1.5 {
+					t.Fatalf("unexpected c: %v", m["c"])
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := NewFormatter(nil, nil, OutputJSON)
+
+			out := f.Format(tt.entry)
+
+			var decoded map[string]any
+			if err := json.Unmarshal([]byte(out), &decoded); err != nil {
+				t.Fatalf("invalid json output: %v\nraw=%s", err, out)
+			}
+
+			tt.assert(t, decoded)
+		})
+	}
+}
+
+func TestFormatter_OutputJSON_MarshalError(t *testing.T) {
+	f := NewFormatter(nil, nil, OutputJSON)
+
+	entry := domain.LogEntry{
+		Raw: "raw-log-line",
+		Fields: map[string]any{
+			"bad": make(chan int), // json.Marshal unsupported type
+		},
+	}
+
+	out := f.Format(entry)
+
+	var decoded map[string]any
+
+	if err := json.Unmarshal([]byte(out), &decoded); err != nil {
+		t.Fatalf("expected valid fallback json, got error: %v", err)
+	}
+
+	if decoded["error"] != "failed to marshal log entry" {
+		t.Fatalf(
+			"expected marshal error message, got %v",
+			decoded["error"],
+		)
+	}
+
+	if decoded["raw"] != "raw-log-line" {
+		t.Fatalf(
+			"expected raw field %q, got %v",
+			"raw-log-line",
+			decoded["raw"],
+		)
+	}
+
+	details, ok := decoded["details"].(string)
+	if !ok || details == "" {
+		t.Fatalf("expected non-empty details field, got %v", decoded["details"])
+	}
+}
+
+func mustParseRFC3339(s string) time.Time {
+	t, err := time.Parse(time.RFC3339Nano, s)
+	if err != nil {
+		panic(err)
+	}
+	return t
 }

--- a/internal/scanner/context_engine.go
+++ b/internal/scanner/context_engine.go
@@ -1,6 +1,8 @@
 package scanner
 
-import "github.com/sagarmaheshwary/reqlog/internal/domain"
+import (
+	"github.com/sagarmaheshwary/reqlog/internal/domain"
+)
 
 type contextEngine struct {
 	beforeBuf      *ringBuffer

--- a/internal/scanner/context_engine_test.go
+++ b/internal/scanner/context_engine_test.go
@@ -14,7 +14,7 @@ func TestContextEngine_Handle(t *testing.T) {
 		contextSize      int
 		cfg              *Config
 		inputs           []ContextLine
-		expectedMessages []string
+		expectedFields   []map[string]any
 		expectedContext  []bool
 		expectedContinue []bool
 	}{
@@ -35,14 +35,14 @@ func TestContextEngine_Handle(t *testing.T) {
 					Service: "svc",
 					IsMatch: true,
 					Entry: &domain.LogEntry{
-						Message:   "user=123",
 						Timestamp: mustParseRFC3339("2024-03-10T12:00:01Z"),
 						Service:   "svc",
+						Fields:    map[string]any{"user": "123"},
 					},
 				},
 			},
-			expectedMessages: []string{
-				"user=123",
+			expectedFields: []map[string]any{
+				{"user": "123"},
 			},
 			expectedContext: []bool{
 				false,
@@ -72,9 +72,9 @@ func TestContextEngine_Handle(t *testing.T) {
 					Service: "svc",
 					IsMatch: true,
 					Entry: &domain.LogEntry{
-						Message:   "user=123",
 						Timestamp: mustParseRFC3339("2024-03-10T12:00:01Z"),
 						Service:   "svc",
+						Fields:    map[string]any{"user": "123"},
 					},
 				},
 				{
@@ -83,10 +83,10 @@ func TestContextEngine_Handle(t *testing.T) {
 					IsMatch: false,
 				},
 			},
-			expectedMessages: []string{
-				"user=before",
-				"user=123",
-				"user=after",
+			expectedFields: []map[string]any{
+				{"user": "before"},
+				{"user": "123"},
+				{"user": "after"},
 			},
 			expectedContext: []bool{
 				true,
@@ -97,42 +97,6 @@ func TestContextEngine_Handle(t *testing.T) {
 				true,
 				true,
 				true,
-			},
-		},
-		{
-			name:        "stops after trailing context exhausted",
-			contextSize: 1,
-			cfg: &Config{
-				Limit:   1,
-				Keys:    []string{"user"},
-				Context: 1,
-			},
-			inputs: []ContextLine{
-				{
-					Line:    "2024-03-10T12:00:00Z user=123",
-					Service: "svc",
-					IsMatch: true,
-					Entry: &domain.LogEntry{
-						Message: "user=123",
-					},
-				},
-				{
-					Line:    "2024-03-10T12:00:01Z user=after",
-					Service: "svc",
-					IsMatch: false,
-				},
-			},
-			expectedMessages: []string{
-				"user=123",
-				"user=after",
-			},
-			expectedContext: []bool{
-				false,
-				true,
-			},
-			expectedContinue: []bool{
-				true,
-				false,
 			},
 		},
 		{
@@ -150,8 +114,8 @@ func TestContextEngine_Handle(t *testing.T) {
 					IsMatch: false,
 				},
 			},
-			expectedMessages: nil,
-			expectedContext:  nil,
+			expectedFields:  nil,
+			expectedContext: nil,
 			expectedContinue: []bool{
 				true,
 			},
@@ -189,33 +153,29 @@ func TestContextEngine_Handle(t *testing.T) {
 				)
 			}
 
-			if len(results) != len(tt.expectedMessages) {
-				t.Fatalf(
-					"expected %d results, got %d",
-					len(tt.expectedMessages),
-					len(results),
-				)
+			var gotCont []bool
+
+			for _, in := range tt.inputs {
+				gotCont = append(gotCont, engine.Handle(in))
 			}
 
-			for i, result := range results {
-				if result.Message != tt.expectedMessages[i] {
-					t.Fatalf(
-						"result[%d]: expected message %q, got %q. %v",
-						i,
-						tt.expectedMessages[i],
-						result.Message,
-						results,
-					)
+			if len(results) != len(tt.expectedFields) {
+				t.Fatalf("len mismatch want=%d got=%d", len(tt.expectedFields), len(results))
+			}
+			for i := range results {
+				if !reflect.DeepEqual(results[i].Fields, tt.expectedFields[i]) {
+					t.Fatalf("fields[%d] mismatch\nwant=%v\ngot=%v",
+						i, tt.expectedFields[i], results[i].Fields)
 				}
 
-				if result.IsContext != tt.expectedContext[i] {
-					t.Fatalf(
-						"result[%d]: expected IsContext=%v, got %v",
-						i,
-						tt.expectedContext[i],
-						result.IsContext,
-					)
+				if results[i].IsContext != tt.expectedContext[i] {
+					t.Fatalf("ctx[%d] mismatch want=%v got=%v",
+						i, tt.expectedContext[i], results[i].IsContext)
 				}
+			}
+
+			if !reflect.DeepEqual(gotCont, tt.expectedContinue) {
+				t.Fatalf("continue mismatch\nwant=%v\ngot=%v", tt.expectedContinue, gotCont)
 			}
 		})
 	}

--- a/internal/scanner/docker_scanner_test.go
+++ b/internal/scanner/docker_scanner_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/sagarmaheshwary/reqlog/internal/docker"
 	"github.com/sagarmaheshwary/reqlog/internal/domain"
+	"github.com/sagarmaheshwary/reqlog/internal/formatter"
 )
 
 var errTest = errors.New("docker error")
@@ -333,34 +334,34 @@ func TestDockerScanner_Scan_Context(t *testing.T) {
 	}
 
 	expected := []struct {
-		message   string
+		raw       string
 		isContext bool
 	}{
 		{
-			message:   "user=ignore",
+			raw:       "2024-03-10T12:00:00Z user=ignore",
 			isContext: true,
 		},
 		{
-			message:   "user=123",
+			raw:       "2024-03-10T12:00:01Z user=123",
 			isContext: false,
 		},
 		{
-			message:   "user=ignore",
+			raw:       "2024-03-10T12:00:02Z user=ignore",
 			isContext: true,
 		},
 		{
-			message:   "user=ignore",
+			raw:       "2024-03-10T12:00:03Z user=ignore",
 			isContext: true,
 		},
 	}
 
 	for i, exp := range expected {
-		if results[i].Message != exp.message {
+		if results[i].Raw != exp.raw {
 			t.Fatalf(
-				"result[%d]: expected message %q, got %q",
+				"result[%d]: expected raw %q, got %q",
 				i,
-				exp.message,
-				results[i].Message,
+				exp.raw,
+				results[i].Raw,
 			)
 		}
 
@@ -462,32 +463,43 @@ func TestDockerScanner_Follow(t *testing.T) {
 		{
 			name: "single container logs",
 			clientLogs: func(container string, follow bool, since string) (io.ReadCloser, error) {
-				return io.NopCloser(strings.NewReader("2024-03-10T12:00:00Z user=123 status=ok")), nil
+				return io.NopCloser(strings.NewReader(
+					"2024-03-10T12:00:00Z user=123 status=ok",
+				)), nil
 			},
 			clientList: func() ([]string, error) { return []string{"auth"}, nil },
 			containers: []string{"auth"},
-			want:       []string{"2024-03-10T12:00:00Z [auth] user=123 status=ok"},
+			want: []string{
+				"2024-03-10T12:00:00Z [auth]",
+			},
 		},
 		{
 			name: "multiple containers",
 			clientLogs: func(container string, follow bool, since string) (io.ReadCloser, error) {
-				if container == "auth" {
-					return io.NopCloser(strings.NewReader("2024-03-10T12:00:00Z user=123")), nil
-				}
-				return io.NopCloser(strings.NewReader("2024-03-10T12:00:00Z user=123")), nil
+				return io.NopCloser(strings.NewReader(
+					"2024-03-10T12:00:00Z user=123",
+				)), nil
 			},
 			clientList: func() ([]string, error) { return []string{"auth", "db"}, nil },
 			containers: []string{"auth", "db"},
-			want:       []string{"2024-03-10T12:00:00Z [auth] user=123", "2024-03-10T12:00:00Z [db] user=123"},
+			want: []string{
+				"[auth]",
+				"[db]",
+			},
 		},
 		{
-			name: "ignore lines that don't match search",
+			name: "ignore non-matching lines",
 			clientLogs: func(container string, follow bool, since string) (io.ReadCloser, error) {
-				return io.NopCloser(strings.NewReader("2024-03-10T12:00:00Z user=123\n2024-03-10T12:00:00Z other=xyz")), nil
+				return io.NopCloser(strings.NewReader(
+					"2024-03-10T12:00:00Z user=123\n" +
+						"2024-03-10T12:00:00Z other=xyz",
+				)), nil
 			},
 			clientList: func() ([]string, error) { return []string{"svc"}, nil },
 			containers: []string{"svc"},
-			want:       []string{"2024-03-10T12:00:00Z [svc] user=123"},
+			want: []string{
+				"[svc]",
+			},
 		},
 		{
 			name: "container returns error",
@@ -513,20 +525,23 @@ func TestDockerScanner_Follow(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
 			defer cancel()
 
-			ds.Follow(ctx, tt.containers, &mockFormatter{})
+			ds.Follow(ctx, tt.containers, &testFormatter{})
 
-			lines := strings.FieldsFunc(out.String(), func(r rune) bool { return r == '\n' || r == '\r' })
+			lines := strings.FieldsFunc(out.String(), func(r rune) bool {
+				return r == '\n' || r == '\r'
+			})
 
 			sort.Strings(lines)
 			want := append([]string(nil), tt.want...)
 			sort.Strings(want)
 
 			if len(lines) != len(want) {
-				t.Fatalf("expected %v lines, got %v", len(want), len(lines))
+				t.Fatalf("expected %d lines, got %d", len(want), len(lines))
 			}
+
 			for i := range lines {
-				if lines[i] != want[i] {
-					t.Errorf("line %d: expected %q, got %q", i, want[i], lines[i])
+				if !strings.Contains(lines[i], want[i]) {
+					t.Errorf("line %d: expected to contain %q, got %q", i, want[i], lines[i])
 				}
 			}
 		})
@@ -555,7 +570,7 @@ func TestDockerScanner_Follow_Errors(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 
-	ds.Follow(ctx, []string{"auth"}, &mockFormatter{})
+	ds.Follow(ctx, []string{"auth"}, formatter.NewFormatter(nil, nil, formatter.OutputPretty))
 
 	if !strings.Contains(errOut.String(), "docker error for auth") {
 		t.Errorf("expected error log, got %q", errOut.String())

--- a/internal/scanner/file_scanner_test.go
+++ b/internal/scanner/file_scanner_test.go
@@ -3,6 +3,7 @@ package scanner
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -11,6 +12,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/sagarmaheshwary/reqlog/internal/domain"
 )
 
 func newTestFileScanner(cfg *Config) *FileScanner {
@@ -403,7 +406,7 @@ func TestFileScanner_Scan_JSON(t *testing.T) {
 	}
 }
 
-func TestFileScanner_ContextWindow_BeforeAndAfter(t *testing.T) {
+func TestFileScanner_Scan_ContextWindow_BeforeAndAfter(t *testing.T) {
 	dir := t.TempDir()
 
 	file := filepath.Join(dir, "svc.log")
@@ -414,12 +417,12 @@ func TestFileScanner_ContextWindow_BeforeAndAfter(t *testing.T) {
 	// line 4-5  -> after-context (must be included)
 	// line 6    -> should NOT be processed (stop after context)
 	writeFile(t, file, []byte(
-		"2024-03-10T12:00:00Z user=ignore\n"+ // before
-			"2024-03-10T12:00:01Z user=123\n"+ // before
-			"2024-03-10T12:00:02Z user=123\n"+ // match
-			"2024-03-10T12:00:03Z user=ignore\n"+ // after-context
-			"2024-03-10T12:00:04Z user=ignore\n"+ // after-context
-			"2024-03-10T12:00:05Z user=123\n", // must NOT be processed
+		"2024-03-10T12:00:00Z some message user=ignore\n"+ // before
+			"2024-03-10T12:00:01Z some message user=123\n"+ // before
+			"2024-03-10T12:00:02Z some message user=123\n"+ // match
+			"2024-03-10T12:00:03Z some message user=ignore\n"+ // after-context
+			"2024-03-10T12:00:04Z some message user=ignore\n"+ // after-context
+			"2024-03-10T12:00:05Z some message user=123\n", // must NOT be processed
 	))
 
 	cfg := &Config{
@@ -436,21 +439,54 @@ func TestFileScanner_ContextWindow_BeforeAndAfter(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	got := make([]string, 0, len(results))
+	got := make([]domain.LogEntry, 0, len(results))
 	for _, r := range results {
-		got = append(got, r.Message)
+		got = append(got, r)
 	}
 
-	expected := []string{
-		"user=ignore", // before buffer
-		"user=123",    // match 1
-
-		"user=123",    // match 2 (NOT context)
-		"user=ignore", // after-context of match 2
+	expected := []domain.LogEntry{
+		{
+			Message:   "some message",
+			Service:   "svc",
+			IsContext: true,
+			Fields: map[string]any{
+				"user": "ignore",
+			},
+		},
+		{
+			Message: "some message",
+			Fields: map[string]any{
+				"user": "123",
+			},
+			IsContext: false,
+		},
+		{
+			Message: "some message",
+			Fields: map[string]any{
+				"user": "123",
+			},
+			IsContext: true,
+		},
+		{
+			Message:   "some message",
+			IsContext: true,
+			Fields: map[string]any{
+				"user": "ignore",
+			},
+		},
 	}
+	for i, exp := range expected {
+		if got[i].Message != exp.Message {
+			t.Fatalf("msg[%d]: expected %q got %q", i, exp.Message, got[i].Message)
+		}
 
-	if !reflect.DeepEqual(got, expected) {
-		t.Fatalf("expected %v, got %v", expected, got)
+		if got[i].IsContext != exp.IsContext {
+			t.Fatalf("ctx[%d]: expected %v got %v", i, exp.IsContext, got[i].IsContext)
+		}
+
+		if !equalFields(got[i].Fields, exp.Fields) {
+			t.Fatalf("fields[%d]: expected %v got %v", i, exp.Fields, got[i].Fields)
+		}
 	}
 }
 
@@ -562,31 +598,31 @@ func TestFileScanner_Follow(t *testing.T) {
 		{
 			name: "single file logs",
 			files: map[string]string{
-				"auth.log": "2024-03-10T12:00:00Z user=123 status=ok\n",
+				"auth.log": "2024-03-10T12:00:00Z request arrived status=ok user=123\n",
 			},
-			want: []string{"2024-03-10T12:00:00Z [auth] user=123 status=ok"},
+			want: []string{"2024-03-10T12:00:00Z [auth] request arrived status=ok user=123"},
 		},
 		{
 			name: "multiple files",
 			files: map[string]string{
-				"auth.log": "2024-03-10T12:00:00Z user=123\n",
-				"db.log":   "2024-03-10T12:00:00Z user=123\n",
+				"auth.log": "2024-03-10T12:00:00Z request arrived user=123\n",
+				"db.log":   "2024-03-10T12:00:00Z request arrived user=123\n",
 			},
-			want: []string{"2024-03-10T12:00:00Z [auth] user=123", "2024-03-10T12:00:00Z [db] user=123"},
+			want: []string{"2024-03-10T12:00:00Z [auth] request arrived user=123", "2024-03-10T12:00:00Z [db] request arrived user=123"},
 		},
 		{
 			name: "ignore lines that don't match search",
 			files: map[string]string{
-				"svc.log": "2024-03-10T12:00:00Z user=123\nother=xyz\n",
+				"svc.log": "2024-03-10T12:00:00Z request arrived user=123\nother=xyz\n",
 			},
-			want: []string{"2024-03-10T12:00:00Z [svc] user=123"},
+			want: []string{"2024-03-10T12:00:00Z [svc] request arrived user=123"},
 		},
 		{
 			name: "new lines appended",
 			files: map[string]string{
 				"append.log": "2024-03-10T12:00:00Z user=123 line1\n",
 			},
-			want: []string{"2024-03-10T12:00:00Z [append] user=123 line1", "2024-03-10T12:00:00Z [append] user=123 line2"},
+			want: []string{"2024-03-10T12:00:00Z [append] line1 user=123", "2024-03-10T12:00:00Z [append] line2 user=123"},
 			append: func() {
 				fpath := filepath.Join(dir, "append.log")
 				f, _ := os.OpenFile(fpath, os.O_APPEND|os.O_WRONLY, 0644)
@@ -622,7 +658,7 @@ func TestFileScanner_Follow(t *testing.T) {
 				}()
 			}
 
-			fs.Follow(ctx, files, &mockFormatter{})
+			fs.Follow(ctx, files, &testFormatter{})
 
 			lines := strings.FieldsFunc(out.String(), func(r rune) bool { return r == '\n' || r == '\r' })
 
@@ -659,9 +695,28 @@ func TestFileScanner_Follow_Errors(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 	defer cancel()
 
-	fs.Follow(ctx, files, &mockFormatter{})
+	fs.Follow(ctx, files, &testFormatter{})
 
 	if !strings.Contains(errOut.String(), "error scanning /tmp/nonexistent.log") {
 		t.Errorf("expected error log, got %q", errOut.String())
 	}
+}
+
+func equalFields(a, b map[string]any) bool {
+	if len(a) != len(b) {
+		return false
+	}
+
+	for k, av := range a {
+		bv, ok := b[k]
+		if !ok {
+			return false
+		}
+
+		if fmt.Sprint(av) != fmt.Sprint(bv) {
+			return false
+		}
+	}
+
+	return true
 }

--- a/internal/scanner/keys.go
+++ b/internal/scanner/keys.go
@@ -12,3 +12,9 @@ var TimestampKeys = []string{
 	"timestamp",
 	"ts",
 }
+
+var MessageKeys = map[string]struct{}{
+	"msg":     {},
+	"message": {},
+	"error":   {},
+}

--- a/internal/scanner/line_processor.go
+++ b/internal/scanner/line_processor.go
@@ -1,7 +1,8 @@
 package scanner
 
 import (
-	"sort"
+	"encoding/json"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -82,10 +83,13 @@ func (lp *LineProcessor) processJSONLine(line string, service string, skipMatch 
 		return nil, false
 	}
 
+	parsedFields := extractJSONFields(obj, tsKey)
+
 	return &domain.LogEntry{
 		Timestamp: ts,
 		Service:   service,
-		Message:   buildJSONMessage(obj, tsKey),
+		Message:   parsedFields.Message,
+		Fields:    parsedFields.Fields,
 	}, true
 }
 
@@ -107,10 +111,14 @@ func (lp *LineProcessor) processTextLine(line string, service string, skipMatch 
 		return nil, false
 	}
 
+	parsed := extractTextFields(parts[1:]) // skip timestamp
+
 	return &domain.LogEntry{
 		Timestamp: ts,
 		Service:   service,
-		Message:   extractTextMessage(line),
+		Message:   parsed.Message,
+		Fields:    parsed.Fields,
+		Raw:       line,
 	}, true
 }
 
@@ -183,36 +191,108 @@ func stripQuotes(val string) string {
 	return val
 }
 
-func buildJSONMessage(obj gjson.Result, tsKey string) string {
-	parts := make([]string, 0, 8)
+type ParsedFields struct {
+	Fields  map[string]any
+	Message string
+}
+
+func extractJSONFields(obj gjson.Result, tsKey string) ParsedFields {
+	fields := make(map[string]any, 8)
+	var message string
 
 	obj.ForEach(func(key, value gjson.Result) bool {
 		k := key.String()
-		if tsKey == k {
+
+		if k == tsKey {
 			return true
 		}
 
-		parts = append(parts, formatJSONField(k, value))
+		v := extractJSONValue(value)
+
+		if _, isMsg := MessageKeys[k]; isMsg {
+			if message == "" {
+				message = value.String()
+			}
+			return true
+		}
+
+		fields[k] = v
 		return true
 	})
 
-	sort.Strings(parts)
-	return strings.Join(parts, " ")
+	return ParsedFields{
+		Fields:  fields,
+		Message: message,
+	}
 }
 
-func formatJSONField(key string, value gjson.Result) string {
+func extractJSONValue(value gjson.Result) any {
 	switch value.Type {
 	case gjson.String:
-		return key + "=" + value.String()
+		return value.String()
+
+	case gjson.Number:
+		return value.Value()
+
+	case gjson.True:
+		return true
+
+	case gjson.False:
+		return false
+
+	case gjson.Null:
+		return nil
+
+	case gjson.JSON:
+		var v any
+		if err := json.Unmarshal([]byte(value.Raw), &v); err == nil {
+			return v
+		}
+
+		return value.Raw
+
 	default:
-		return key + "=" + value.Raw
+		return value.Raw
 	}
 }
 
-func extractTextMessage(line string) string {
-	i := strings.IndexByte(line, ' ')
-	if i == -1 {
-		return ""
+func extractTextFields(parts []string) ParsedFields {
+	fields := make(map[string]any, 8)
+	messageParts := make([]string, 0, len(parts))
+
+	for _, part := range parts {
+		key, value, ok := strings.Cut(part, "=")
+		if ok && key != "" {
+			fields[key] = parseTextValue(value)
+			continue
+		}
+
+		messageParts = append(messageParts, part)
 	}
-	return strings.TrimLeft(line[i+1:], " ")
+
+	return ParsedFields{
+		Fields:  fields,
+		Message: strings.Join(messageParts, " "),
+	}
+}
+
+func parseTextValue(v string) any {
+	if strings.ContainsAny(v, ".eE") {
+		if f, err := strconv.ParseFloat(v, 64); err == nil {
+			return f
+		}
+	}
+
+	if i, err := strconv.ParseInt(v, 10, 64); err == nil {
+		return i
+	}
+
+	switch strings.ToLower(v) {
+	case "true":
+		return true
+	case "false":
+		return false
+	}
+
+	return v
 }

--- a/internal/scanner/line_processor_test.go
+++ b/internal/scanner/line_processor_test.go
@@ -1,6 +1,8 @@
 package scanner
 
 import (
+	"encoding/json"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -200,10 +202,10 @@ func TestLineProcessor_ParseOnly(t *testing.T) {
 		{
 			name:    "valid text log",
 			cfg:     &Config{},
-			line:    "2024-03-10T12:00:00Z user=999 status=ok",
+			line:    "2024-03-10T12:00:00Z some message user=999 status=ok",
 			service: "auth",
 			wantOK:  true,
-			wantMsg: "user=999 status=ok",
+			wantMsg: "some message",
 			wantSvc: "auth",
 		},
 		{
@@ -525,104 +527,264 @@ func TestStripQuotes(t *testing.T) {
 	}
 }
 
-func TestBuildJSONMessage(t *testing.T) {
+func TestExtractJSONFields(t *testing.T) {
+	MessageKeys = map[string]struct{}{
+		"msg":     {},
+		"message": {},
+	}
+
 	tests := []struct {
-		name   string
-		json   string
-		tsKey  string
-		expect string
+		name        string
+		input       string
+		tsKey       string
+		wantMessage string
+		wantFields  map[string]any
 	}{
 		{
-			name:   "exclude timestamp",
-			json:   `{"timestamp":"1","a":"x","b":"y"}`,
-			tsKey:  "timestamp",
-			expect: "a=x b=y",
+			name: "basic fields with message",
+			input: `{
+				"ts": "2024-03-10T12:00:00Z",
+				"level": "info",
+				"msg": "hello world",
+				"user": "123"
+			}`,
+			tsKey:       "ts",
+			wantMessage: "hello world",
+			wantFields: map[string]any{
+				"level": "info",
+				"user":  "123",
+			},
 		},
 		{
-			name:   "sorted output",
-			json:   `{"b":"y","a":"x"}`,
-			tsKey:  "timestamp",
-			expect: "a=x b=y",
+			name: "number and boolean parsing",
+			input: `{
+				"ts": "2024-03-10T12:00:00Z",
+				"count": 42,
+				"ok": true,
+				"msg": "done"
+			}`,
+			tsKey:       "ts",
+			wantMessage: "done",
+			wantFields: map[string]any{
+				"count": float64(42),
+				"ok":    true,
+			},
 		},
 		{
-			name:   "non-string values use raw",
-			json:   `{"a":1,"b":true}`,
-			tsKey:  "timestamp",
-			expect: "a=1 b=true",
+			name: "null and nested json",
+			input: `{
+				"ts": "2024-03-10T12:00:00Z",
+				"data": {"a": 1},
+				"extra": null
+			}`,
+			tsKey:       "ts",
+			wantMessage: "",
+			wantFields: map[string]any{
+				"data": map[string]any{
+					"a": float64(1),
+				},
+				"extra": nil,
+			},
+		},
+		{
+			name: "array parsing",
+			input: `{
+				"ts": "2024-03-10T12:00:00Z",
+				"tags": ["a", "b"]
+			}`,
+			tsKey: "ts",
+			wantFields: map[string]any{
+				"tags": []any{"a", "b"},
+			},
+		},
+		{
+			name: "timestamp key excluded",
+			input: `{
+				"ts": "2024-03-10T12:00:00Z",
+				"user": "123"
+			}`,
+			tsKey: "ts",
+			wantFields: map[string]any{
+				"user": "123",
+			},
+		},
+		{
+			name: "message only once (first match wins)",
+			input: `{
+				"ts": "2024-03-10T12:00:00Z",
+				"msg": "first",
+				"message": "second",
+				"user": "123"
+			}`,
+			tsKey:       "ts",
+			wantMessage: "first",
+			wantFields: map[string]any{
+				"user": "123",
+			},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			obj := gjson.Parse(tt.json)
+			obj := gjson.Parse(tt.input)
 
-			msg := buildJSONMessage(obj, tt.tsKey)
+			got := extractJSONFields(obj, tt.tsKey)
 
-			if msg != tt.expect {
-				t.Fatalf("expected %s, got %s", tt.expect, msg)
+			if got.Message != tt.wantMessage {
+				t.Fatalf("message: expected %q got %q", tt.wantMessage, got.Message)
+			}
+
+			if len(got.Fields) != len(tt.wantFields) {
+				t.Fatalf("fields length: expected %d got %d", len(tt.wantFields), len(got.Fields))
+			}
+
+			for k, v := range tt.wantFields {
+				gv, ok := got.Fields[k]
+				if !ok {
+					t.Fatalf("missing field %q", k)
+				}
+
+				// deep compare JSON-safe values
+				gotB, _ := json.Marshal(gv)
+				wantB, _ := json.Marshal(v)
+
+				if string(gotB) != string(wantB) {
+					t.Fatalf("field %q: expected %v got %v", k, v, gv)
+				}
 			}
 		})
 	}
 }
 
-func TestFormatJSONField(t *testing.T) {
+func TestExtractTextFields(t *testing.T) {
 	tests := []struct {
-		name     string
-		json     string
-		key      string
-		expected string
+		name  string
+		input []string
+		want  ParsedFields
 	}{
 		{
-			name:     "string value",
-			json:     `{"a":"x"}`,
-			key:      "a",
-			expected: "a=x",
+			name: "fields first then message",
+			input: []string{
+				"level=info",
+				"request_id=abc123",
+				"start",
+				"request",
+			},
+			want: ParsedFields{
+				Fields: map[string]any{
+					"level":      "info",
+					"request_id": "abc123",
+				},
+				Message: "start request",
+			},
 		},
 		{
-			name:     "number value",
-			json:     `{"a":1}`,
-			key:      "a",
-			expected: "a=1",
+			name: "message first then fields",
+			input: []string{
+				"start",
+				"request",
+				"level=info",
+				"request_id=abc123",
+			},
+			want: ParsedFields{
+				Fields: map[string]any{
+					"level":      "info",
+					"request_id": "abc123",
+				},
+				Message: "start request",
+			},
 		},
 		{
-			name:     "bool value",
-			json:     `{"a":true}`,
-			key:      "a",
-			expected: "a=true",
+			name: "mixed ordering",
+			input: []string{
+				"start",
+				"level=info",
+				"request",
+				"request_id=abc123",
+			},
+			want: ParsedFields{
+				Fields: map[string]any{
+					"level":      "info",
+					"request_id": "abc123",
+				},
+				Message: "start request",
+			},
+		},
+		{
+			name: "typed values",
+			input: []string{
+				"ok=true",
+				"count=10",
+				"rate=1.5",
+				"done",
+			},
+			want: ParsedFields{
+				Fields: map[string]any{
+					"ok":    true,
+					"count": int64(10),
+					"rate":  1.5,
+				},
+				Message: "done",
+			},
+		},
+		{
+			name: "no fields only message",
+			input: []string{
+				"hello",
+				"world",
+			},
+			want: ParsedFields{
+				Fields:  map[string]any{},
+				Message: "hello world",
+			},
+		},
+		{
+			name: "no message only fields",
+			input: []string{
+				"level=info",
+				"request_id=abc123",
+			},
+			want: ParsedFields{
+				Fields: map[string]any{
+					"level":      "info",
+					"request_id": "abc123",
+				},
+				Message: "",
+			},
+		},
+		{
+			name:  "empty input",
+			input: []string{},
+			want: ParsedFields{
+				Fields:  map[string]any{},
+				Message: "",
+			},
+		},
+		{
+			name: "value with equals ignored split safety",
+			input: []string{
+				"query=a=b=c",
+				"run",
+			},
+			want: ParsedFields{
+				Fields: map[string]any{
+					"query": "a=b=c",
+				},
+				Message: "run",
+			},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			obj := gjson.Parse(tt.json)
-			val := obj.Get(tt.key)
+			got := extractTextFields(tt.input)
 
-			got := formatJSONField(tt.key, val)
-
-			if got != tt.expected {
-				t.Fatalf("expected %s, got %s", tt.expected, got)
+			if !reflect.DeepEqual(got.Fields, tt.want.Fields) {
+				t.Fatalf("fields mismatch\nwant: %+v\ngot:  %+v", tt.want.Fields, got.Fields)
 			}
-		})
-	}
-}
 
-func TestExtractTextMessage(t *testing.T) {
-	tests := []struct {
-		input    string
-		expected string
-	}{
-		{"ts message here", "message here"},
-		{"ts    message here", "message here"},
-		{"singlefield", ""},
-		{"ts ", ""},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.input, func(t *testing.T) {
-			got := extractTextMessage(tt.input)
-
-			if got != tt.expected {
-				t.Fatalf("expected %q, got %q", tt.expected, got)
+			if got.Message != tt.want.Message {
+				t.Fatalf("message mismatch\nwant: %q\ngot:  %q", tt.want.Message, got.Message)
 			}
 		})
 	}

--- a/internal/scanner/mocks_test.go
+++ b/internal/scanner/mocks_test.go
@@ -1,7 +1,10 @@
 package scanner
 
 import (
+	"fmt"
 	"io"
+	"sort"
+	"strings"
 	"time"
 
 	"github.com/sagarmaheshwary/reqlog/internal/domain"
@@ -20,8 +23,28 @@ func (m *mockDockerClient) ListContainers() ([]string, error) {
 	return m.listFn()
 }
 
-type mockFormatter struct{}
+type testFormatter struct{}
 
-func (f *mockFormatter) Format(entry domain.LogEntry) string {
-	return entry.Timestamp.Format(time.RFC3339) + " [" + entry.Service + "] " + entry.Message
+func (f *testFormatter) Format(entry domain.LogEntry) string {
+	keys := make([]string, 0, len(entry.Fields))
+
+	for k := range entry.Fields {
+		keys = append(keys, k)
+	}
+
+	sort.Strings(keys)
+
+	var fields []string
+
+	for _, k := range keys {
+		fields = append(fields, fmt.Sprintf("%s=%v", k, entry.Fields[k]))
+	}
+
+	return fmt.Sprintf(
+		"%s [%s] %s %s",
+		entry.Timestamp.Format(time.RFC3339),
+		entry.Service,
+		entry.Message,
+		strings.Join(fields, " "),
+	)
 }


### PR DESCRIPTION
## Summary

This PR adds structured JSON output support to reqlog and refactors the formatting pipeline to separate parsing from presentation.

## Changes

- add `--output=json` mode for machine-readable output and piping integrations
- parse structured fields during log processing instead of formatting log lines early
- preserve typed field values (`int`, `bool`, `float`, nested JSON) for structured output
- separate pretty/text and JSON formatting implementations
- flatten structured fields in JSON output for better interoperability with tools like `jq`
- extract message fields (`msg`/`message`) into a dedicated `LogEntry.Message`
- improve field ordering and formatting in pretty output
- add test coverage for new parsing and formatter logic
- update existing tests for the new structured log flow

## Example

Pretty output:

```bash
2026-03-20T14:00:05Z [order-service] | request started level=info request_id=abc123
```

JSON output:

```json
{
  "timestamp": "2026-03-20T14:00:05Z",
  "service": "order-service",
  "message": "request started",
  "level": "info",
  "request_id": "abc123"
}
```
