### PR TITLE
refactor(cli): improve flag system, add format modes, and simplify scanner logic

### DIFF
--- a/cmd/reqlog/main.go
+++ b/cmd/reqlog/main.go
@@ -56,6 +56,7 @@ func run(cfg *config.Config) {
 		Services:    cfg.Services,
 		Latest:      cfg.Latest,
 		Context:     cfg.Context,
+		Format:      cfg.Format,
 	}, scanner.NewTimeParser())
 	scn, err := scanner.New(cfg.Source, lp)
 	if err != nil {

--- a/cmd/reqlog/main.go
+++ b/cmd/reqlog/main.go
@@ -8,124 +8,56 @@ import (
 	"os"
 	"runtime/debug"
 	"sort"
-	"strings"
 
-	"github.com/sagarmaheshwary/reqlog/internal/domain"
+	"github.com/sagarmaheshwary/reqlog/internal/cli"
+	"github.com/sagarmaheshwary/reqlog/internal/config"
 	"github.com/sagarmaheshwary/reqlog/internal/formatter"
 	"github.com/sagarmaheshwary/reqlog/internal/scanner"
 )
 
-var (
-	dir         = flag.String("dir", "./logs", "directory containing log files")
-	ignoreCase  = flag.Bool("ignore-case", false, "perform case-insensitive search")
-	limit       = flag.Int("limit", 0, "limit number of results")
-	latest      = flag.Bool("latest", false, "return globally latest N matches across all sources")
-	jsonMode    = flag.Bool("json", false, "parse logs as JSON (one JSON object per line)")
-	follow      = flag.Bool("follow", false, "follow logs in real time (like tail -f)")
-	key         = flag.String("key", "", "field key to match (e.g. request_id, trace_id, event_key)")
-	since       = flag.String("since", "", "filter logs newer than: duration (5m, 1h), RFC3339 timestamp, or YYYY-MM-DD (UTC)")
-	recursive   = flag.Bool("recursive", true, "scan directories recursively")
-	service     = flag.String("service", "", "filter by service name (comma-separated, e.g. order-service,inventory-service)")
-	source      = flag.String("source", "file", `log source backend ("file" or "docker")`)
-	versionFlag = flag.Bool("version", false, "print version and exit")
-	contextFlag = flag.Int("context", 0, "show N lines of context before and after each match")
-	output      = flag.String("output", "pretty", `output format ("pretty" or "json")`)
-)
-
 var version = "dev"
 
-var cliInfo = `Usage:
-  reqlog [flags] <search_value>
-
-Description:
-  Search logs by exact key=value matching across log files.
-
-Examples:
-  # Basic search
-  reqlog abc123
-
-  # Search in a specific directory
-  reqlog --dir ./logs abc123
-
-  # Case-insensitive search
-  reqlog --ignore-case abc123
-
-  # Limit results
-  reqlog --limit 10 abc123
-
-  # Filter by key
-  reqlog --key request_id abc123
-  reqlog --key event_key order.created
-
-  # JSON logs
-  reqlog --json --key trace_id trace-1
-
-  # Filter recent logs
-  reqlog --since 5m abc123
-
-  # Filter specific services
-  reqlog --service order-service,inventory-service abc123
-
-  # Non-recursive scan
-  reqlog --recursive=false abc123
-
-  # Follow logs (tail mode)
-  reqlog --follow abc123
-
-  # Combined example (real-world usage)
-  reqlog \
-    --dir ./logs \
-    --service api-gateway,order-service \
-    --key event_key \
-    --since 10m \
-    --limit 20 \
-    order.created`
+func init() {
+	flag.Usage = cli.Usage
+}
 
 func main() {
-	flag.Parse()
+	cfg, err := cli.ParseConfig()
+	if err != nil {
+		log.Fatal(err.Error())
+	}
 
-	if *versionFlag {
+	if cfg.Version {
 		fmt.Printf("reqlog version %s\n", cliVersion())
 		return
 	}
 
 	if flag.NArg() < 1 {
 		if flag.NArg() < 1 {
-			fmt.Println(cliInfo)
+			fmt.Println(cli.Info())
 			os.Exit(1)
 		}
 	}
 
-	SearchValue := flag.Arg(0)
+	cfg.SearchValue = flag.Arg(0)
 
-	keys := scanner.DefaultKeys
-	if *key != "" {
-		keys = []string{*key}
-	}
+	run(cfg)
+}
 
-	services := []string{}
-	if *service != "" {
-		services = strings.Split(*service, ",")
-	}
-
-	if *latest && *limit == 0 {
-		log.Fatal("--latest requires --limit")
-	}
-
-	cfg := &scanner.Config{
-		Dir:         *dir,
-		SearchValue: SearchValue,
-		IgnoreCase:  *ignoreCase,
-		Keys:        keys,
-		Since:       *since,
-		Limit:       *limit,
-		Recursive:   *recursive,
-		Services:    services,
-		JSONMode:    *jsonMode,
-		Latest:      *latest,
-		Context:     *contextFlag,
-	}
-	scn, err := scanner.New(*source, scanner.NewLineProcessor(cfg, scanner.NewTimeParser()))
+func run(cfg *config.Config) {
+	lp := scanner.NewLineProcessor(&scanner.Config{
+		Dir:         cfg.Dir,
+		SearchValue: cfg.SearchValue,
+		IgnoreCase:  cfg.IgnoreCase,
+		Keys:        cfg.Keys,
+		Since:       cfg.Since,
+		Limit:       cfg.Limit,
+		Recursive:   cfg.Recursive,
+		Services:    cfg.Services,
+		Latest:      cfg.Latest,
+		Context:     cfg.Context,
+	}, scanner.NewTimeParser())
+	scn, err := scanner.New(cfg.Source, lp)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -144,11 +76,21 @@ func main() {
 		log.Fatal(err)
 	}
 
-	f := formatter.NewFormatter(entries, keys, formatter.OutputFormat(*output))
+	f := formatter.NewFormatter(&formatter.Opts{
+		Entries:    entries,
+		SearchKeys: cfg.Keys,
+		Output:     cfg.Output,
+		Context:    cfg.Context,
+	})
 
-	printEntries(f, entries)
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].Timestamp.Before(entries[j].Timestamp)
+	})
+	for _, e := range entries {
+		fmt.Println(f.Format(e))
+	}
 
-	if *follow {
+	if cfg.Follow {
 		scn.Follow(context.Background(), sources, f)
 	}
 }
@@ -168,14 +110,4 @@ func cliVersion() string {
 	}
 
 	return "dev"
-}
-
-func printEntries(f formatter.LogFormatter, entries []domain.LogEntry) {
-	sort.Slice(entries, func(i, j int) bool {
-		return entries[i].Timestamp.Before(entries[j].Timestamp)
-	})
-
-	for _, e := range entries {
-		fmt.Println(f.Format(e))
-	}
 }

--- a/internal/cli/flags.go
+++ b/internal/cli/flags.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"flag"
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/sagarmaheshwary/reqlog/internal/config"
@@ -21,7 +22,10 @@ func ParseConfig() (*config.Config, error) {
 
 	opts := registerFlags(cfg)
 
-	flag.Parse()
+	err := flag.CommandLine.Parse(normalizeArgs(os.Args[1:]))
+	if err != nil {
+		return nil, err
+	}
 
 	applyDerivedConfig(cfg, opts)
 
@@ -184,6 +188,35 @@ func validateConfig(cfg *config.Config) error {
 	}
 
 	return nil
+}
+
+func normalizeArgs(args []string) []string {
+	out := make([]string, 0, len(args))
+
+	for _, arg := range args {
+		if isTailStyleLimit(arg) {
+			out = append(out, "-n", arg[1:])
+			continue
+		}
+
+		out = append(out, arg)
+	}
+
+	return out
+}
+
+func isTailStyleLimit(arg string) bool {
+	if len(arg) < 2 || arg[0] != '-' {
+		return false
+	}
+
+	for _, ch := range arg[1:] {
+		if ch < '0' || ch > '9' {
+			return false
+		}
+	}
+
+	return true
 }
 
 func stringFlag(target *string, name, short, def, usage string) {

--- a/internal/cli/flags.go
+++ b/internal/cli/flags.go
@@ -1,0 +1,211 @@
+package cli
+
+import (
+	"flag"
+	"fmt"
+	"strings"
+
+	"github.com/sagarmaheshwary/reqlog/internal/config"
+)
+
+type flagOptions struct {
+	key     string
+	service string
+	source  string
+	output  string
+	format  string
+}
+
+func ParseConfig() (*config.Config, error) {
+	cfg := &config.Config{}
+
+	opts := registerFlags(cfg)
+
+	flag.Parse()
+
+	applyDerivedConfig(cfg, opts)
+
+	if err := validateConfig(cfg); err != nil {
+		return nil, err
+	}
+
+	return cfg, nil
+}
+
+func registerFlags(cfg *config.Config) *flagOptions {
+	opts := &flagOptions{}
+
+	stringFlag(
+		&cfg.Dir,
+		"dir",
+		"d",
+		"./logs",
+		"directory containing log files",
+	)
+
+	boolFlag(
+		&cfg.IgnoreCase,
+		"ignore-case",
+		"i",
+		false,
+		"perform case-insensitive search",
+	)
+
+	intFlag(
+		&cfg.Limit,
+		"limit",
+		"n",
+		0,
+		"limit number of results",
+	)
+
+	boolFlag(
+		&cfg.Latest,
+		"latest",
+		"l",
+		false,
+		"return globally latest N matches across all sources",
+	)
+
+	boolFlag(
+		&cfg.Follow,
+		"follow",
+		"f",
+		false,
+		"follow logs in real time",
+	)
+
+	stringFlag(
+		&opts.key,
+		"key",
+		"k",
+		"",
+		"field key to match (e.g. request_id, trace_id, event_key)",
+	)
+
+	stringFlag(
+		&cfg.Since,
+		"since",
+		"t",
+		"",
+		"filter logs newer than: duration (5m, 1h), RFC3339 timestamp, or YYYY-MM-DD (UTC)",
+	)
+
+	boolFlag(
+		&cfg.Recursive,
+		"recursive",
+		"r",
+		true,
+		"scan directories recursively",
+	)
+
+	stringFlag(
+		&opts.service,
+		"service",
+		"s",
+		"",
+		"filter by service name (comma-separated, e.g. order-service,inventory-service)",
+	)
+
+	stringFlag(
+		&opts.source,
+		"source",
+		"S",
+		"file",
+		`log source backend ("file" or "docker")`,
+	)
+
+	boolFlag(
+		&cfg.Version,
+		"version",
+		"v",
+		false,
+		"print version and exit",
+	)
+
+	intFlag(
+		&cfg.Context,
+		"context",
+		"c",
+		0,
+		"show N lines of context before and after each match",
+	)
+
+	stringFlag(
+		&opts.output,
+		"output",
+		"o",
+		"pretty",
+		`output format ("pretty" or "json")`,
+	)
+
+	stringFlag(
+		&opts.format,
+		"format",
+		"F",
+		"auto",
+		`log parsing format ("auto", "json", or "text")`,
+	)
+
+	return opts
+}
+
+func applyDerivedConfig(cfg *config.Config, opts *flagOptions) {
+	cfg.Keys = config.DefaultKeys
+
+	if opts.key != "" {
+		cfg.Keys = []string{opts.key}
+	}
+
+	if opts.service != "" {
+		cfg.Services = strings.Split(opts.service, ",")
+	}
+
+	cfg.Source = config.Source(opts.source)
+	cfg.Output = config.OutputFormat(opts.output)
+	cfg.Format = config.LogFormat(opts.format)
+}
+
+func validateConfig(cfg *config.Config) error {
+	switch cfg.Output {
+	case config.OutputPretty, config.OutputJSON:
+	default:
+		return fmt.Errorf("invalid output format: %s", cfg.Output)
+	}
+
+	switch cfg.Format {
+	case config.FormatAuto, config.FormatJSON, config.FormatText:
+	default:
+		return fmt.Errorf("invalid log format: %s", cfg.Format)
+	}
+
+	if cfg.Latest && cfg.Limit == 0 {
+		return fmt.Errorf("--latest requires --limit")
+	}
+
+	return nil
+}
+
+func stringFlag(target *string, name, short, def, usage string) {
+	flag.StringVar(target, name, def, usage)
+
+	if short != "" {
+		flag.StringVar(target, short, def, "")
+	}
+}
+
+func boolFlag(target *bool, name, short string, def bool, usage string) {
+	flag.BoolVar(target, name, def, usage)
+
+	if short != "" {
+		flag.BoolVar(target, short, def, "")
+	}
+}
+
+func intFlag(target *int, name, short string, def int, usage string) {
+	flag.IntVar(target, name, def, usage)
+
+	if short != "" {
+		flag.IntVar(target, short, def, "")
+	}
+}

--- a/internal/cli/flags_test.go
+++ b/internal/cli/flags_test.go
@@ -1,0 +1,180 @@
+package cli
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/sagarmaheshwary/reqlog/internal/config"
+)
+
+func TestIsTailStyleLimit(t *testing.T) {
+	tests := []struct {
+		arg  string
+		want bool
+	}{
+		{"-10", true},
+		{"-1", true},
+		{"-999", true},
+
+		{"10", false},
+		{"--10", false},
+		{"-n", false},
+		{"-abc", false},
+		{"-1a", false},
+		{"-", false},
+		{"", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.arg, func(t *testing.T) {
+			got := isTailStyleLimit(tt.arg)
+
+			if got != tt.want {
+				t.Fatalf("expected %v got %v", tt.want, got)
+			}
+		})
+	}
+}
+
+func TestNormalizeArgs(t *testing.T) {
+	tests := []struct {
+		name string
+		in   []string
+		want []string
+	}{
+		{
+			name: "tail style limit",
+			in:   []string{"-10"},
+			want: []string{"-n", "10"},
+		},
+		{
+			name: "mixed args",
+			in:   []string{"--follow", "-20", "abc123"},
+			want: []string{"--follow", "-n", "20", "abc123"},
+		},
+		{
+			name: "normal args unchanged",
+			in:   []string{"--limit", "10"},
+			want: []string{"--limit", "10"},
+		},
+		{
+			name: "non numeric dash arg unchanged",
+			in:   []string{"-abc"},
+			want: []string{"-abc"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := normalizeArgs(tt.in)
+
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("expected %v got %v", tt.want, got)
+			}
+		})
+	}
+}
+
+func TestApplyDerivedConfig(t *testing.T) {
+	cfg := &config.Config{}
+
+	opts := &flagOptions{
+		key:     "trace_id",
+		service: "auth,db",
+		source:  "docker",
+		output:  "json",
+		format:  "text",
+	}
+
+	applyDerivedConfig(cfg, opts)
+
+	if !reflect.DeepEqual(cfg.Keys, []string{"trace_id"}) {
+		t.Fatalf("keys: expected %v got %v", []string{"trace_id"}, cfg.Keys)
+	}
+
+	if !reflect.DeepEqual(cfg.Services, []string{"auth", "db"}) {
+		t.Fatalf("services: expected %v got %v", []string{"auth", "db"}, cfg.Services)
+	}
+
+	if cfg.Source != config.SourceDocker {
+		t.Fatalf("source: expected %v got %v", config.SourceDocker, cfg.Source)
+	}
+
+	if cfg.Output != config.OutputJSON {
+		t.Fatalf("output: expected %v got %v", config.OutputJSON, cfg.Output)
+	}
+
+	if cfg.Format != config.FormatText {
+		t.Fatalf("format: expected %v got %v", config.FormatText, cfg.Format)
+	}
+}
+func TestValidateConfig(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfg     *config.Config
+		wantErr bool
+	}{
+		{
+			name: "valid pretty output",
+			cfg: &config.Config{
+				Output: config.OutputPretty,
+				Format: config.FormatAuto,
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid json output",
+			cfg: &config.Config{
+				Output: config.OutputJSON,
+				Format: config.FormatJSON,
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid output",
+			cfg: &config.Config{
+				Output: "xml",
+				Format: config.FormatAuto,
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid format",
+			cfg: &config.Config{
+				Output: config.OutputPretty,
+				Format: "yaml",
+			},
+			wantErr: true,
+		},
+		{
+			name: "latest without limit",
+			cfg: &config.Config{
+				Output: config.OutputPretty,
+				Format: config.FormatAuto,
+				Latest: true,
+				Limit:  0,
+			},
+			wantErr: true,
+		},
+		{
+			name: "latest with limit",
+			cfg: &config.Config{
+				Output: config.OutputPretty,
+				Format: config.FormatAuto,
+				Latest: true,
+				Limit:  10,
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateConfig(tt.cfg)
+
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("expected error=%v got err=%v", tt.wantErr, err)
+			}
+		})
+	}
+}

--- a/internal/cli/usage.go
+++ b/internal/cli/usage.go
@@ -28,6 +28,9 @@ Flags:
   -n, --limit int
         limit number of results
 
+        Tail-style shorthand is also supported:
+        reqlog -100 abc123
+
   -l, --latest
         return globally latest N matches across all sources
 

--- a/internal/cli/usage.go
+++ b/internal/cli/usage.go
@@ -1,0 +1,78 @@
+package cli
+
+import (
+	"flag"
+	"fmt"
+)
+
+func Usage() {
+	fmt.Fprintf(flag.CommandLine.Output(), `reqlog - Search and trace requests across microservices, files, and Docker logs — fast.
+
+Usage:
+  reqlog [flags] <search_value>
+
+Examples:
+  reqlog abc123
+  reqlog -k request_id abc123
+  reqlog -S docker -s order-service abc123
+  reqlog -f -o json abc123 | jq
+
+Flags:
+  -d, --dir string
+        directory containing log files
+        (default "./logs")
+
+  -i, --ignore-case
+        perform case-insensitive search
+
+  -n, --limit int
+        limit number of results
+
+  -l, --latest
+        return globally latest N matches across all sources
+
+  -f, --follow
+        follow logs in real time
+
+  -k, --key string
+        field key to match
+        (e.g. request_id, trace_id, event_key)
+
+  -t, --since string
+        filter logs newer than:
+        duration (5m, 1h), RFC3339 timestamp, or YYYY-MM-DD
+
+  -r, --recursive
+        scan directories recursively
+
+  -s, --service string
+        filter by service name
+        (comma-separated)
+
+  -S, --source string
+        log source backend ("file" or "docker")
+        (default "file")
+
+  -c, --context int
+        show N lines of context before and after each match
+
+  -o, --output string
+        output format ("pretty" or "json")
+        (default "pretty")
+
+  -F, --format string
+        log parsing format ("auto", "json", or "text")
+        (default "auto")
+
+  -v, --version
+        print version and exit
+`)
+}
+
+func Info() string {
+	return `Usage:
+  reqlog [flags] <search_value>
+
+Run 'reqlog --help' for more information.
+`
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,50 @@
+package config
+
+type OutputFormat string
+
+const (
+	OutputPretty OutputFormat = "pretty"
+	OutputJSON   OutputFormat = "json"
+)
+
+type LogFormat string
+
+const (
+	FormatAuto LogFormat = "auto"
+	FormatJSON LogFormat = "json"
+	FormatText LogFormat = "text"
+)
+
+type Source string
+
+const (
+	SourceFile   Source = "file"
+	SourceDocker Source = "docker"
+)
+
+type Config struct {
+	Version     bool
+	Dir         string
+	SearchValue string
+	IgnoreCase  bool
+	Keys        []string
+	Since       string
+	Limit       int
+	Recursive   bool
+	Services    []string
+	Latest      bool
+	Context     int
+
+	Source Source
+	Follow bool
+
+	Output OutputFormat
+	Format LogFormat
+}
+
+var DefaultKeys = []string{
+	"request_id",
+	"req_id",
+	"trace_id",
+	"correlation_id",
+}

--- a/internal/formatter/formatter.go
+++ b/internal/formatter/formatter.go
@@ -8,28 +8,30 @@ import (
 	"strings"
 	"time"
 
+	"github.com/sagarmaheshwary/reqlog/internal/config"
 	"github.com/sagarmaheshwary/reqlog/internal/domain"
 )
 
 var tsFormat = "2006-01-02T15:04:05.000Z07:00"
 
-type OutputFormat string
-
-const (
-	OutputPretty OutputFormat = "pretty"
-	OutputJSON   OutputFormat = "json"
-)
-
 type Formatter struct {
 	colorizer    *Colorizer
 	serviceWidth int
 	searchKeys   []string
-	output       OutputFormat
+	output       config.OutputFormat
+	context      int
 }
 
-func NewFormatter(entries []domain.LogEntry, searchKeys []string, output OutputFormat) *Formatter {
+type Opts struct {
+	Entries    []domain.LogEntry
+	SearchKeys []string
+	Output     config.OutputFormat
+	Context    int
+}
+
+func NewFormatter(opts *Opts) *Formatter {
 	max := 0
-	for _, e := range entries {
+	for _, e := range opts.Entries {
 		if len(e.Service) > max {
 			max = len(e.Service)
 		}
@@ -38,8 +40,9 @@ func NewFormatter(entries []domain.LogEntry, searchKeys []string, output OutputF
 	return &Formatter{
 		colorizer:    NewColorizer(),
 		serviceWidth: max,
-		searchKeys:   searchKeys,
-		output:       output,
+		searchKeys:   opts.SearchKeys,
+		output:       opts.Output,
+		context:      opts.Context,
 	}
 }
 
@@ -52,10 +55,10 @@ func (f *Formatter) padAfter(service string) string {
 
 func (f *Formatter) Format(entry domain.LogEntry) string {
 	switch f.output {
-	case OutputJSON:
+	case config.OutputJSON:
 		return f.outputJSON(entry)
 
-	case OutputPretty:
+	case config.OutputPretty:
 		fallthrough
 
 	default:
@@ -69,7 +72,10 @@ func (f *Formatter) outputJSON(entry domain.LogEntry) string {
 	out["timestamp"] = entry.Timestamp.Format(time.RFC3339Nano)
 	out["service"] = entry.Service
 	out["message"] = entry.Message
-	out["context"] = entry.IsContext
+
+	if f.context > 0 {
+		out["context"] = entry.IsContext
+	}
 
 	for k, v := range entry.Fields {
 		// avoid accidental overwrite of core keys

--- a/internal/formatter/formatter_test.go
+++ b/internal/formatter/formatter_test.go
@@ -195,9 +195,10 @@ func mustParseTime(t *testing.T, s string) time.Time {
 
 func TestFormatter_OutputJSON(t *testing.T) {
 	tests := []struct {
-		name   string
-		entry  domain.LogEntry
-		assert func(t *testing.T, m map[string]any)
+		name    string
+		entry   domain.LogEntry
+		context int
+		assert  func(t *testing.T, m map[string]any)
 	}{
 		{
 			name: "basic json output",
@@ -210,6 +211,7 @@ func TestFormatter_OutputJSON(t *testing.T) {
 				},
 				IsContext: false,
 			},
+			context: 0,
 			assert: func(t *testing.T, m map[string]any) {
 				if m["service"] != "auth" {
 					t.Fatalf("service mismatch: %v", m["service"])
@@ -231,6 +233,7 @@ func TestFormatter_OutputJSON(t *testing.T) {
 				Message:   "login",
 				IsContext: true,
 			},
+			context: 1,
 			assert: func(t *testing.T, m map[string]any) {
 				if m["context"] != true {
 					t.Fatalf("expected context=true, got %v", m["context"])
@@ -251,6 +254,7 @@ func TestFormatter_OutputJSON(t *testing.T) {
 					"context":   "override-context",
 				},
 			},
+			context: 1,
 			assert: func(t *testing.T, m map[string]any) {
 				if m["timestamp"] == "override-ts" {
 					t.Fatalf("timestamp should NOT be overwritten")
@@ -283,6 +287,7 @@ func TestFormatter_OutputJSON(t *testing.T) {
 					"c": 1.5,
 				},
 			},
+			context: 0,
 			assert: func(t *testing.T, m map[string]any) {
 				if m["a"] != float64(1) && m["a"] != 1 {
 					t.Fatalf("unexpected a: %v", m["a"])
@@ -299,14 +304,9 @@ func TestFormatter_OutputJSON(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			context := 0
-			if tt.entry.IsContext {
-				context = 1
-			}
-
 			f := NewFormatter(&Opts{
 				Output:  config.OutputJSON,
-				Context: context,
+				Context: tt.context,
 			})
 
 			out := f.Format(tt.entry)

--- a/internal/formatter/formatter_test.go
+++ b/internal/formatter/formatter_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/sagarmaheshwary/reqlog/internal/config"
 	"github.com/sagarmaheshwary/reqlog/internal/domain"
 )
 
@@ -25,7 +26,7 @@ func TestFormat_HighlightSearchKey(t *testing.T) {
 		colorizer:    NewColorizer(),
 		searchKeys:   []string{"request_id"},
 		serviceWidth: len("api"),
-		output:       OutputPretty,
+		output:       config.OutputPretty,
 	}
 
 	out := f.Format(entry)
@@ -73,8 +74,11 @@ func TestFormat_OutputStructure(t *testing.T) {
 		{Service: "longer-service"},
 	}
 
-	f := NewFormatter(entries, []string{"request_id"}, OutputPretty)
-
+	f := NewFormatter(&Opts{
+		Entries:    entries,
+		SearchKeys: []string{"request_id"},
+		Output:     config.OutputPretty,
+	})
 	out := f.Format(entry)
 
 	if !strings.Contains(out, ts.Format(tsFormat)) {
@@ -156,7 +160,9 @@ func TestSortKVByPriority(t *testing.T) {
 }
 
 func TestFormatter_Format_ContextEntry(t *testing.T) {
-	f := NewFormatter(nil, nil, OutputPretty)
+	f := NewFormatter(&Opts{
+		Output: config.OutputPretty,
+	})
 
 	entry := domain.LogEntry{
 		Timestamp: mustParseTime(t, "2024-03-10T12:00:00Z"),
@@ -293,7 +299,15 @@ func TestFormatter_OutputJSON(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			f := NewFormatter(nil, nil, OutputJSON)
+			context := 0
+			if tt.entry.IsContext {
+				context = 1
+			}
+
+			f := NewFormatter(&Opts{
+				Output:  config.OutputJSON,
+				Context: context,
+			})
 
 			out := f.Format(tt.entry)
 
@@ -308,7 +322,9 @@ func TestFormatter_OutputJSON(t *testing.T) {
 }
 
 func TestFormatter_OutputJSON_MarshalError(t *testing.T) {
-	f := NewFormatter(nil, nil, OutputJSON)
+	f := NewFormatter(&Opts{
+		Output: config.OutputJSON,
+	})
 
 	entry := domain.LogEntry{
 		Raw: "raw-log-line",

--- a/internal/scanner/config.go
+++ b/internal/scanner/config.go
@@ -1,5 +1,7 @@
 package scanner
 
+import "github.com/sagarmaheshwary/reqlog/internal/config"
+
 type Config struct {
 	Dir         string
 	SearchValue string
@@ -9,7 +11,7 @@ type Config struct {
 	Limit       int
 	Recursive   bool
 	Services    []string
-	JSONMode    bool
 	Latest      bool
 	Context     int
+	Format      config.LogFormat
 }

--- a/internal/scanner/context_engine.go
+++ b/internal/scanner/context_engine.go
@@ -59,7 +59,7 @@ func (c *contextEngine) Handle(in ContextLine) bool {
 		return true
 	}
 
-	entry, ok := c.lineProcessor.ParseOnly(in.Line, in.Service)
+	entry, ok := c.lineProcessor.Parse(in.Line, in.Service, true)
 	if !ok {
 		return true
 	}

--- a/internal/scanner/docker_scanner_test.go
+++ b/internal/scanner/docker_scanner_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/sagarmaheshwary/reqlog/internal/config"
 	"github.com/sagarmaheshwary/reqlog/internal/docker"
 	"github.com/sagarmaheshwary/reqlog/internal/domain"
 	"github.com/sagarmaheshwary/reqlog/internal/formatter"
@@ -200,7 +201,7 @@ func TestDockerScanner_Scan_JSON(t *testing.T) {
 			cfg := &Config{
 				SearchValue: "123",
 				Keys:        []string{"user"},
-				JSONMode:    true,
+				Format:      config.FormatJSON,
 			}
 
 			ds := newTestDockerScanner(cfg, mock)
@@ -570,7 +571,10 @@ func TestDockerScanner_Follow_Errors(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 
-	ds.Follow(ctx, []string{"auth"}, formatter.NewFormatter(nil, nil, formatter.OutputPretty))
+	f := formatter.NewFormatter(&formatter.Opts{
+		Output: config.OutputPretty,
+	})
+	ds.Follow(ctx, []string{"auth"}, f)
 
 	if !strings.Contains(errOut.String(), "docker error for auth") {
 		t.Errorf("expected error log, got %q", errOut.String())

--- a/internal/scanner/factory.go
+++ b/internal/scanner/factory.go
@@ -5,14 +5,15 @@ import (
 	"os"
 	"time"
 
+	"github.com/sagarmaheshwary/reqlog/internal/config"
 	"github.com/sagarmaheshwary/reqlog/internal/docker"
 )
 
-func New(source string, lp *LineProcessor) (Scanner, error) {
+func New(source config.Source, lp *LineProcessor) (Scanner, error) {
 	switch source {
-	case "file":
+	case config.SourceFile:
 		return NewFileScanner(lp, time.Second, os.Stdout, os.Stderr, time.Now()), nil
-	case "docker":
+	case config.SourceDocker:
 		return NewDockerScanner(lp, docker.NewDockerCLIClient(), os.Stdout, os.Stderr, time.Now()), nil
 	default:
 		return nil, fmt.Errorf("unknown source type")

--- a/internal/scanner/factory_test.go
+++ b/internal/scanner/factory_test.go
@@ -1,6 +1,10 @@
 package scanner
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/sagarmaheshwary/reqlog/internal/config"
+)
 
 func TestNewScanner(t *testing.T) {
 	cfg := &Config{}
@@ -8,13 +12,13 @@ func TestNewScanner(t *testing.T) {
 
 	tests := []struct {
 		name    string
-		source  string
+		source  config.Source
 		wantErr bool
 		check   func(t *testing.T, s Scanner)
 	}{
 		{
 			name:   "file source",
-			source: "file",
+			source: config.SourceFile,
 			check: func(t *testing.T, s Scanner) {
 				if _, ok := s.(*FileScanner); !ok {
 					t.Fatalf("expected *FileScanner")
@@ -23,7 +27,7 @@ func TestNewScanner(t *testing.T) {
 		},
 		{
 			name:   "docker source",
-			source: "docker",
+			source: config.SourceDocker,
 			check: func(t *testing.T, s Scanner) {
 				if _, ok := s.(*DockerScanner); !ok {
 					t.Fatalf("expected *DockerScanner")

--- a/internal/scanner/file_scanner.go
+++ b/internal/scanner/file_scanner.go
@@ -167,11 +167,92 @@ func (fs *FileScanner) processFile(path string, f formatter.LogFormatter) {
 
 func (fs *FileScanner) ListSources() ([]string, error) {
 	cfg := fs.lineProcessor.config
+
+	matcher := buildServiceMatcher(cfg.Services)
+
+	if cfg.Recursive {
+		return fs.listRecursive(cfg.Dir, matcher)
+	}
+
+	return fs.listFlat(cfg.Dir, matcher)
+}
+
+func (fs *FileScanner) listRecursive(
+	dir string,
+	matchesService func(string) bool,
+) ([]string, error) {
+	files := make([]string, 0, 16)
+
+	err := filepath.WalkDir(
+		dir,
+		func(path string, d os.DirEntry, err error) error {
+			if err != nil {
+				logScanError(fs.errOut, path, err)
+				return nil // continue walking
+			}
+
+			if d.IsDir() {
+				return nil
+			}
+
+			name := d.Name()
+
+			if !isLogFile(name) {
+				return nil
+			}
+
+			if !matchesService(name) {
+				return nil
+			}
+
+			files = append(files, path)
+
+			return nil
+		},
+	)
+
+	return files, err
+}
+
+func (fs *FileScanner) listFlat(
+	dir string,
+	matchesService func(string) bool,
+) ([]string, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, err
+	}
+
+	files := make([]string, 0, 16)
+
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+
+		name := entry.Name()
+
+		if !isLogFile(name) {
+			continue
+		}
+
+		if !matchesService(name) {
+			continue
+		}
+
+		files = append(files, filepath.Join(dir, name))
+	}
+
+	return files, nil
+}
+
+func buildServiceMatcher(services []string) func(string) bool {
 	exact := map[string]struct{}{}
 	prefixes := []string{}
 
-	for _, s := range cfg.Services {
+	for _, s := range services {
 		s = strings.TrimSpace(s)
+
 		if s == "" {
 			continue
 		}
@@ -183,7 +264,7 @@ func (fs *FileScanner) ListSources() ([]string, error) {
 		}
 	}
 
-	matchesService := func(name string) bool {
+	return func(name string) bool {
 		if len(exact) == 0 && len(prefixes) == 0 {
 			return true
 		}
@@ -199,62 +280,11 @@ func (fs *FileScanner) ListSources() ([]string, error) {
 				return true
 			}
 		}
+
 		return false
 	}
+}
 
-	if cfg.Recursive {
-		files := make([]string, 0, 16)
-
-		err := filepath.WalkDir(cfg.Dir, func(path string, d os.DirEntry, err error) error {
-			if err != nil {
-				logScanError(fs.errOut, path, err)
-				return nil // continue walking
-			}
-
-			if d.IsDir() {
-				return nil
-			}
-
-			name := d.Name()
-
-			if !strings.HasSuffix(name, ".log") {
-				return nil
-			}
-
-			if !matchesService(name) {
-				return nil
-			}
-
-			files = append(files, path)
-			return nil
-		})
-		return files, err
-	}
-
-	entries, err := os.ReadDir(cfg.Dir)
-	if err != nil {
-		return nil, err
-	}
-
-	files := make([]string, 0, 16)
-
-	for _, entry := range entries {
-		if entry.IsDir() {
-			continue
-		}
-
-		name := entry.Name()
-
-		if !strings.HasSuffix(name, ".log") {
-			continue
-		}
-
-		if !matchesService(name) {
-			continue
-		}
-
-		files = append(files, filepath.Join(cfg.Dir, name))
-	}
-
-	return files, nil
+func isLogFile(name string) bool {
+	return strings.HasSuffix(name, ".log")
 }

--- a/internal/scanner/file_scanner_benchmark_test.go
+++ b/internal/scanner/file_scanner_benchmark_test.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/sagarmaheshwary/reqlog/internal/config"
 )
 
 func createPlainLogFile(b *testing.B, dir, name string, lines int, matchEvery int) string {
@@ -78,9 +80,9 @@ func BenchmarkScanDir_PlainText(b *testing.B) {
 			Dir:         dir,
 			SearchValue: "abc123",
 			IgnoreCase:  false,
-			Keys:        DefaultKeys,
+			Keys:        config.DefaultKeys,
 			Since:       "",
-			JSONMode:    false,
+			Format:      config.FormatText,
 		}
 		lp := NewLineProcessor(cfg, NewTimeParser())
 
@@ -111,9 +113,9 @@ func BenchmarkScanDir_JSON(b *testing.B) {
 			Dir:         dir,
 			SearchValue: "json-abc",
 			IgnoreCase:  false,
-			Keys:        DefaultKeys,
+			Keys:        config.DefaultKeys,
 			Since:       "",
-			JSONMode:    true,
+			Format:      config.FormatJSON,
 		}
 		lp := NewLineProcessor(cfg, NewTimeParser())
 

--- a/internal/scanner/file_scanner_test.go
+++ b/internal/scanner/file_scanner_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/sagarmaheshwary/reqlog/internal/config"
 	"github.com/sagarmaheshwary/reqlog/internal/domain"
 )
 
@@ -383,7 +384,7 @@ func TestFileScanner_Scan_JSON(t *testing.T) {
 				Dir:         dir,
 				SearchValue: "123",
 				Keys:        []string{"user"},
-				JSONMode:    true,
+				Format:      config.FormatJSON,
 			}
 
 			lp := NewLineProcessor(cfg, NewTimeParser())

--- a/internal/scanner/keys.go
+++ b/internal/scanner/keys.go
@@ -1,12 +1,5 @@
 package scanner
 
-var DefaultKeys = []string{
-	"request_id",
-	"req_id",
-	"trace_id",
-	"correlation_id",
-}
-
 var TimestampKeys = []string{
 	"time",
 	"timestamp",

--- a/internal/scanner/line_processor.go
+++ b/internal/scanner/line_processor.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/sagarmaheshwary/reqlog/internal/config"
 	"github.com/sagarmaheshwary/reqlog/internal/domain"
 	"github.com/tidwall/gjson"
 )
@@ -38,26 +39,25 @@ func (lp *LineProcessor) ProcessLine(line, service string) (*domain.LogEntry, bo
 		}
 	}
 
-	if lp.config.JSONMode {
-		return lp.processJSONLine(line, service, false)
-	}
-
-	return lp.processTextLine(
-		strings.TrimRight(line, "\r\n"),
-		service,
-		false,
-	)
+	return lp.Parse(line, service, false)
 }
 
-func (lp *LineProcessor) ParseOnly(line, service string) (*domain.LogEntry, bool) {
-	if lp.config.JSONMode {
-		return lp.processJSONLine(line, service, true)
+func (lp *LineProcessor) Parse(line, service string, skipMatch bool) (*domain.LogEntry, bool) {
+	line = strings.TrimRight(line, "\r\n")
+
+	switch lp.config.Format {
+	case config.FormatJSON:
+		return lp.processJSONLine(line, service, skipMatch)
+	case config.FormatText:
+		return lp.processTextLine(line, service, skipMatch)
+	case config.FormatAuto:
+		fallthrough
+	default:
+		if isJSONLine(line) {
+			return lp.processJSONLine(line, service, skipMatch)
+		}
+		return lp.processTextLine(line, service, skipMatch)
 	}
-	return lp.processTextLine(
-		strings.TrimRight(line, "\r\n"),
-		service,
-		true,
-	)
 }
 
 func (lp *LineProcessor) processJSONLine(line string, service string, skipMatch bool) (*domain.LogEntry, bool) {
@@ -295,4 +295,14 @@ func parseTextValue(v string) any {
 	}
 
 	return v
+}
+
+func isJSONLine(line string) bool {
+	line = strings.TrimSpace(line)
+
+	if len(line) < 2 {
+		return false
+	}
+
+	return line[0] == '{'
 }

--- a/internal/scanner/line_processor_test.go
+++ b/internal/scanner/line_processor_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/sagarmaheshwary/reqlog/internal/config"
 	"github.com/tidwall/gjson"
 )
 
@@ -71,7 +72,7 @@ func TestLineProcessor_ProcessLine_TextMode(t *testing.T) {
 				SearchValue: tt.searchValue,
 				IgnoreCase:  tt.ignoreCase,
 				Keys:        tt.keys,
-				JSONMode:    false,
+				Format:      config.FormatText,
 			}
 
 			lp := NewLineProcessor(cfg, tp)
@@ -168,7 +169,7 @@ func TestLineProcessor_ProcessLine_JSONMode(t *testing.T) {
 				SearchValue: tt.searchValue,
 				IgnoreCase:  tt.ignoreCase,
 				Keys:        tt.keys,
-				JSONMode:    true,
+				Format:      config.FormatJSON,
 			}
 
 			lp := NewLineProcessor(cfg, tp)
@@ -188,7 +189,7 @@ func TestLineProcessor_ProcessLine_JSONMode(t *testing.T) {
 	}
 }
 
-func TestLineProcessor_ParseOnly(t *testing.T) {
+func TestLineProcessor_Parse(t *testing.T) {
 	tests := []struct {
 		name      string
 		cfg       *Config
@@ -227,7 +228,7 @@ func TestLineProcessor_ParseOnly(t *testing.T) {
 		{
 			name: "valid json log",
 			cfg: &Config{
-				JSONMode: true,
+				Format: config.FormatJSON,
 			},
 			line:    `{"time":"2024-03-10T12:00:00Z","user":"999","status":"ok"}`,
 			service: "api",
@@ -237,7 +238,7 @@ func TestLineProcessor_ParseOnly(t *testing.T) {
 		{
 			name: "invalid json log",
 			cfg: &Config{
-				JSONMode: true,
+				Format: config.FormatJSON,
 			},
 			line:      `{"time":"2024-03-10T12:00:00Z"`,
 			service:   "api",
@@ -247,7 +248,7 @@ func TestLineProcessor_ParseOnly(t *testing.T) {
 		{
 			name: "json missing timestamp",
 			cfg: &Config{
-				JSONMode: true,
+				Format: config.FormatJSON,
 			},
 			line:      `{"user":"123"}`,
 			service:   "api",
@@ -260,7 +261,7 @@ func TestLineProcessor_ParseOnly(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			lp := NewLineProcessor(tt.cfg, NewTimeParser())
 
-			entry, ok := lp.ParseOnly(tt.line, tt.service)
+			entry, ok := lp.Parse(tt.line, tt.service, true)
 
 			if ok != tt.wantOK {
 				t.Fatalf("expected ok=%v, got %v", tt.wantOK, ok)
@@ -306,7 +307,7 @@ func TestLineProcessor_JSONTimestampKeyCaching(t *testing.T) {
 	cfg := &Config{
 		SearchValue: "abc",
 		Keys:        []string{"request_id"},
-		JSONMode:    true,
+		Format:      config.FormatJSON,
 	}
 
 	lp := NewLineProcessor(cfg, tp)

--- a/internal/scanner/line_processor_test.go
+++ b/internal/scanner/line_processor_test.go
@@ -255,6 +255,16 @@ func TestLineProcessor_Parse(t *testing.T) {
 			wantOK:    false,
 			wantIsNil: true,
 		},
+		{
+			name: "auto detect json",
+			cfg: &Config{
+				Format: config.FormatAuto,
+			},
+			line:    `{"time":"2024-03-10T12:00:00Z","user":"999","status":"ok"}`,
+			service: "api",
+			wantOK:  true,
+			wantSvc: "api",
+		},
 	}
 
 	for _, tt := range tests {
@@ -786,6 +796,209 @@ func TestExtractTextFields(t *testing.T) {
 
 			if got.Message != tt.want.Message {
 				t.Fatalf("message mismatch\nwant: %q\ngot:  %q", tt.want.Message, got.Message)
+			}
+		})
+	}
+}
+
+func TestExtractJSONValue(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		key   string
+		want  any
+	}{
+		{
+			name:  "string value",
+			input: `{"v":"hello"}`,
+			key:   "v",
+			want:  "hello",
+		},
+		{
+			name:  "integer number",
+			input: `{"v":42}`,
+			key:   "v",
+			want:  float64(42),
+		},
+		{
+			name:  "float number",
+			input: `{"v":3.14}`,
+			key:   "v",
+			want:  3.14,
+		},
+		{
+			name:  "true boolean",
+			input: `{"v":true}`,
+			key:   "v",
+			want:  true,
+		},
+		{
+			name:  "false boolean",
+			input: `{"v":false}`,
+			key:   "v",
+			want:  false,
+		},
+		{
+			name:  "null value",
+			input: `{"v":null}`,
+			key:   "v",
+			want:  nil,
+		},
+		{
+			name:  "object json",
+			input: `{"v":{"a":1}}`,
+			key:   "v",
+			want: map[string]any{
+				"a": float64(1),
+			},
+		},
+		{
+			name:  "array json",
+			input: `{"v":["a","b"]}`,
+			key:   "v",
+			want:  []any{"a", "b"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := gjson.Parse(tt.input).Get(tt.key)
+
+			got := extractJSONValue(result)
+
+			gotB, _ := json.Marshal(got)
+			wantB, _ := json.Marshal(tt.want)
+
+			if string(gotB) != string(wantB) {
+				t.Fatalf("expected %s got %s", string(wantB), string(gotB))
+			}
+		})
+	}
+}
+
+func TestParseTextValue(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  any
+	}{
+		{
+			name:  "integer",
+			input: "42",
+			want:  int64(42),
+		},
+		{
+			name:  "negative integer",
+			input: "-10",
+			want:  int64(-10),
+		},
+		{
+			name:  "float",
+			input: "3.14",
+			want:  3.14,
+		},
+		{
+			name:  "scientific notation lowercase",
+			input: "1e3",
+			want:  1000.0,
+		},
+		{
+			name:  "scientific notation uppercase",
+			input: "2E2",
+			want:  200.0,
+		},
+		{
+			name:  "true boolean lowercase",
+			input: "true",
+			want:  true,
+		},
+		{
+			name:  "false boolean lowercase",
+			input: "false",
+			want:  false,
+		},
+		{
+			name:  "true boolean uppercase",
+			input: "TRUE",
+			want:  true,
+		},
+		{
+			name:  "plain string",
+			input: "hello",
+			want:  "hello",
+		},
+		{
+			name:  "alphanumeric string",
+			input: "abc123",
+			want:  "abc123",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseTextValue(tt.input)
+
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("expected %#v got %#v", tt.want, got)
+			}
+		})
+	}
+}
+
+func TestIsJSONLine(t *testing.T) {
+	tests := []struct {
+		name string
+		line string
+		want bool
+	}{
+		{
+			name: "valid json object",
+			line: `{"msg":"hello"}`,
+			want: true,
+		},
+		{
+			name: "valid json with leading whitespace",
+			line: "   \t  {\"msg\":\"hello\"}",
+			want: true,
+		},
+		{
+			name: "empty string",
+			line: "",
+			want: false,
+		},
+		{
+			name: "whitespace only",
+			line: "   \n\t  ",
+			want: false,
+		},
+		{
+			name: "single opening brace",
+			line: "{",
+			want: false,
+		},
+		{
+			name: "plain text log",
+			line: "2024-03-10T12:00:00Z level=info",
+			want: false,
+		},
+		{
+			name: "json array should be false",
+			line: `["a","b"]`,
+			want: false,
+		},
+		{
+			name: "starts with bracket after whitespace",
+			line: "   [1,2,3]",
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isJSONLine(tt.line)
+
+			if got != tt.want {
+				t.Fatalf("expected %v got %v", tt.want, got)
 			}
 		})
 	}


### PR DESCRIPTION
### Overview

This PR introduces a significant CLI and internal refactor for `reqlog`, improving usability, configurability, and internal architecture. It also enhances log parsing flexibility and test coverage.

The changes focus on:

- improving CLI ergonomics (shorthands, help, and new flags)
- replacing legacy `--json` flag with a unified `--format` system
- adding tail-style shorthand support for `--limit`
- improving log parsing test coverage
- simplifying file scanning and service matching logic

### Features

- Added `--format=auto|json|text` flag for log parsing
  - `auto` mode automatically detects JSON vs text logs

- Added shorthand flags for all major CLI options
- Added tail-style limit support:
  - `-100` → equivalent to `--limit 100`

- Improved `--help` output and CLI usability

### Changes

- Replaced deprecated `--json` flag with `--format`
- Centralized CLI configuration into `internal/cli`
- Introduced shared `internal/config` structure for app-wide settings
- Refactored `FileScanner`:
  - separated recursive and flat listing logic
  - extracted service matching into reusable helper
  - improved readability of `ListSources`

### Testing

- Added test coverage for `internal/cli`
- Improved `TestFormatter_OutputJSON` structure
- Added tests for:
  - `FormatAuto`
  - `extractJSONValue`
  - `parseTextValue`
  - `isJSONLine`

- Ensured CLI parsing edge cases (including shorthand flags) are covered

### Refactoring

- Simplified `ListSources` orchestration logic
- Reduced duplication between recursive and flat file scanning
- Improved separation of concerns in CLI vs scanner layers
- Cleaner parsing pipeline for JSON/text log handling

### ⚠️ Breaking Changes

- `--json` flag removed
  - Replace usage with:

    ```bash
    --format=json
    ```

### Example Usage

```bash
reqlog abc123
reqlog -k request_id abc123
reqlog -S docker -s order-service abc123
reqlog -f -o json abc123 | jq
reqlog -100 abc123
```
