### PR TITLE
fix: initialize file follow offset at EOF after scan

### DIFF
--- a/internal/scanner/file_scanner.go
+++ b/internal/scanner/file_scanner.go
@@ -91,6 +91,10 @@ func (fs *FileScanner) Scan(files []string) ([]domain.LogEntry, error) {
 				}
 			}
 
+			stat, err := file.Stat()
+			if err == nil {
+				offset = stat.Size()
+			}
 			return offset, nil
 		}()
 


### PR DESCRIPTION
Fixes an issue where `reqlog -f` could replay existing matching log lines after the initial scan when used with `-n` or other early-stop conditions.

FileScanner now initializes follow offsets from EOF after scan completion.