### PR TITLE
feat: add config.yaml support for SSH logs and config overrides

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,10 @@ module github.com/sagarmaheshwary/reqlog
 
 go 1.25.5
 
-require github.com/tidwall/gjson v1.18.0
+require (
+	github.com/tidwall/gjson v1.18.0
+	go.yaml.in/yaml/v4 v4.0.0-rc.4
+)
 
 require (
 	github.com/tidwall/match v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,3 +4,5 @@ github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=
 github.com/tidwall/match v1.1.1/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
 github.com/tidwall/pretty v1.2.0 h1:RWIZEg2iJ8/g6fDDYzMpobmaoGh5OLl4AXtGUGPcqCs=
 github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
+go.yaml.in/yaml/v4 v4.0.0-rc.4 h1:UP4+v6fFrBIb1l934bDl//mmnoIZEDK0idg1+AIvX5U=
+go.yaml.in/yaml/v4 v4.0.0-rc.4/go.mod h1:aZqd9kCMsGL7AuUv/m/PvWLdg5sjJsZ4oHDEnfPPfY0=

--- a/internal/cli/flags.go
+++ b/internal/cli/flags.go
@@ -15,6 +15,7 @@ type flagOptions struct {
 	source  string
 	output  string
 	format  string
+	config  string
 }
 
 func ParseConfig() (*config.Config, error) {
@@ -27,7 +28,9 @@ func ParseConfig() (*config.Config, error) {
 		return nil, err
 	}
 
-	applyDerivedConfig(cfg, opts)
+	if err := applyDerivedConfig(cfg, opts); err != nil {
+		return nil, err
+	}
 
 	if err := validateConfig(cfg); err != nil {
 		return nil, err
@@ -151,10 +154,26 @@ func registerFlags(cfg *config.Config) *flagOptions {
 		`log parsing format ("auto", "json", or "text")`,
 	)
 
+	stringFlag(
+		&opts.config,
+		"config",
+		"",
+		"",
+		"path to SSH config file",
+	)
+
+	stringFlag(
+		&cfg.Host,
+		"host",
+		"H",
+		"",
+		"SSH host alias from config file",
+	)
+
 	return opts
 }
 
-func applyDerivedConfig(cfg *config.Config, opts *flagOptions) {
+func applyDerivedConfig(cfg *config.Config, opts *flagOptions) error {
 	cfg.Keys = config.DefaultKeys
 
 	if opts.key != "" {
@@ -168,6 +187,16 @@ func applyDerivedConfig(cfg *config.Config, opts *flagOptions) {
 	cfg.Source = config.Source(opts.source)
 	cfg.Output = config.OutputFormat(opts.output)
 	cfg.Format = config.LogFormat(opts.format)
+
+	if cfg.Host != "" {
+		var err error
+		cfg.Config, err = config.NewSSH(opts.config)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 func validateConfig(cfg *config.Config) error {

--- a/internal/cli/flags_test.go
+++ b/internal/cli/flags_test.go
@@ -76,38 +76,73 @@ func TestNormalizeArgs(t *testing.T) {
 }
 
 func TestApplyDerivedConfig(t *testing.T) {
-	cfg := &config.Config{}
+	t.Run("applies derived values", func(t *testing.T) {
+		cfg := &config.Config{}
 
-	opts := &flagOptions{
-		key:     "trace_id",
-		service: "auth,db",
-		source:  "docker",
-		output:  "json",
-		format:  "text",
-	}
+		opts := &flagOptions{
+			key:     "trace_id",
+			service: "auth,db",
+			source:  "docker",
+			output:  "json",
+			format:  "text",
+		}
 
-	applyDerivedConfig(cfg, opts)
+		err := applyDerivedConfig(cfg, opts)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
 
-	if !reflect.DeepEqual(cfg.Keys, []string{"trace_id"}) {
-		t.Fatalf("keys: expected %v got %v", []string{"trace_id"}, cfg.Keys)
-	}
+		if !reflect.DeepEqual(cfg.Keys, []string{"trace_id"}) {
+			t.Fatalf("keys: expected %v got %v", []string{"trace_id"}, cfg.Keys)
+		}
 
-	if !reflect.DeepEqual(cfg.Services, []string{"auth", "db"}) {
-		t.Fatalf("services: expected %v got %v", []string{"auth", "db"}, cfg.Services)
-	}
+		if !reflect.DeepEqual(cfg.Services, []string{"auth", "db"}) {
+			t.Fatalf("services: expected %v got %v", []string{"auth", "db"}, cfg.Services)
+		}
 
-	if cfg.Source != config.SourceDocker {
-		t.Fatalf("source: expected %v got %v", config.SourceDocker, cfg.Source)
-	}
+		if cfg.Source != config.SourceDocker {
+			t.Fatalf("source: expected %v got %v", config.SourceDocker, cfg.Source)
+		}
 
-	if cfg.Output != config.OutputJSON {
-		t.Fatalf("output: expected %v got %v", config.OutputJSON, cfg.Output)
-	}
+		if cfg.Output != config.OutputJSON {
+			t.Fatalf("output: expected %v got %v", config.OutputJSON, cfg.Output)
+		}
 
-	if cfg.Format != config.FormatText {
-		t.Fatalf("format: expected %v got %v", config.FormatText, cfg.Format)
-	}
+		if cfg.Format != config.FormatText {
+			t.Fatalf("format: expected %v got %v", config.FormatText, cfg.Format)
+		}
+	})
+
+	t.Run("uses default keys when key not provided", func(t *testing.T) {
+		cfg := &config.Config{}
+		opts := &flagOptions{}
+
+		err := applyDerivedConfig(cfg, opts)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if !reflect.DeepEqual(cfg.Keys, config.DefaultKeys) {
+			t.Fatalf("keys: expected %v got %v", config.DefaultKeys, cfg.Keys)
+		}
+	})
+
+	t.Run("returns ssh config error when host is set", func(t *testing.T) {
+		cfg := &config.Config{
+			Host: "prod",
+		}
+
+		opts := &flagOptions{
+			config: "/does/not/exist.yaml",
+		}
+
+		err := applyDerivedConfig(cfg, opts)
+		if err == nil {
+			t.Fatal("expected error")
+		}
+	})
 }
+
 func TestValidateConfig(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/internal/cli/usage.go
+++ b/internal/cli/usage.go
@@ -6,7 +6,7 @@ import (
 )
 
 func Usage() {
-	fmt.Fprintf(flag.CommandLine.Output(), `reqlog - Search and trace requests across microservices, files, and Docker logs — fast.
+	fmt.Fprintf(flag.CommandLine.Output(), `reqlog - Search and trace requests across files, Docker, and SSH logs — fast.
 
 Usage:
   reqlog [flags] <search_value>
@@ -15,6 +15,8 @@ Examples:
   reqlog abc123
   reqlog -k request_id abc123
   reqlog -S docker -s order-service abc123
+  reqlog -H srv1 -d /path/to/logs abc123
+  reqlog --config ~/.config/reqlog/config.yaml -H srv1 -d /path/to/logs abc123
   reqlog -f -o json abc123 | jq
 
 Flags:
@@ -55,6 +57,12 @@ Flags:
   -S, --source string
         log source backend ("file" or "docker")
         (default "file")
+
+  -H, --host string
+        SSH host alias from config file
+
+      --config string
+        path to SSH config file
 
   -c, --context int
         show N lines of context before and after each match

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -40,6 +40,9 @@ type Config struct {
 
 	Output OutputFormat
 	Format LogFormat
+
+	Host   string
+	Config *SSH
 }
 
 var DefaultKeys = []string{

--- a/internal/config/ssh.go
+++ b/internal/config/ssh.go
@@ -1,0 +1,105 @@
+package config
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"go.yaml.in/yaml/v4"
+)
+
+type SSH struct {
+	Defaults Defaults        `yaml:"defaults"`
+	Hosts    map[string]Host `yaml:"hosts"`
+}
+
+type Defaults struct {
+	Key string `yaml:"key"`
+}
+
+type Host struct {
+	Host string `yaml:"host"`
+	User string `yaml:"user"`
+	Port int    `yaml:"port"`
+	Key  string `yaml:"key"`
+}
+
+const sshDefaultPort = 22
+
+func NewSSH(path string) (*SSH, error) {
+	if path == "" {
+		userConfig, err := os.UserConfigDir()
+		if err != nil {
+			return nil, fmt.Errorf("get user config dir: %w", err)
+		}
+		path = filepath.Join(userConfig, "reqlog", "config.yaml")
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, fmt.Errorf(
+				"SSH config not found: %s\nCreate one or pass --config <path>",
+				path,
+			)
+		} else {
+			return nil, fmt.Errorf("read ssh config %q: %w", path, err)
+		}
+	}
+
+	cfg, err := ParseSSH(data)
+	if err != nil {
+		return nil, fmt.Errorf("parse ssh config %q: %w", path, err)
+	}
+
+	return cfg, nil
+}
+
+func ParseSSH(data []byte) (*SSH, error) {
+	var cfg SSH
+
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("unmarshal yaml: %w", err)
+	}
+
+	cfg.assignDefaults()
+
+	if err := cfg.validate(); err != nil {
+		return nil, fmt.Errorf("validate config: %w", err)
+	}
+
+	return &cfg, nil
+}
+
+func (c *SSH) validate() error {
+	if len(c.Hosts) == 0 {
+		return errors.New("ssh config: no hosts defined")
+	}
+
+	for alias, h := range c.Hosts {
+		if h.Host == "" {
+			return fmt.Errorf("host %q: missing host", alias)
+		}
+		if h.User == "" {
+			return fmt.Errorf("host %q: missing user", alias)
+		}
+		if h.Key == "" {
+			return fmt.Errorf("host %q: missing key", alias)
+		}
+	}
+
+	return nil
+}
+
+func (c *SSH) assignDefaults() {
+	for k, v := range c.Hosts {
+		if v.Port == 0 {
+			v.Port = sshDefaultPort
+		}
+		if v.Key == "" {
+			v.Key = c.Defaults.Key
+		}
+		c.Hosts[k] = v
+	}
+}

--- a/internal/config/ssh_test.go
+++ b/internal/config/ssh_test.go
@@ -1,0 +1,162 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestParseSSH(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    *SSH
+		wantErr string
+	}{
+		{
+			name: "valid config with defaults applied",
+			input: `
+defaults:
+  key: ~/.ssh/id_rsa
+
+hosts:
+  prod:
+    host: prod.example.com
+    user: ubuntu
+`,
+			want: &SSH{
+				Defaults: Defaults{
+					Key: "~/.ssh/id_rsa",
+				},
+				Hosts: map[string]Host{
+					"prod": {
+						Host: "prod.example.com",
+						User: "ubuntu",
+						Port: sshDefaultPort,
+						Key:  "~/.ssh/id_rsa",
+					},
+				},
+			},
+		},
+		{
+			name: "explicit values override defaults",
+			input: `
+defaults:
+  key: ~/.ssh/id_rsa
+
+hosts:
+  prod:
+    host: prod.example.com
+    user: ubuntu
+    port: 2222
+    key: ~/.ssh/custom_key
+`,
+			want: &SSH{
+				Defaults: Defaults{
+					Key: "~/.ssh/id_rsa",
+				},
+				Hosts: map[string]Host{
+					"prod": {
+						Host: "prod.example.com",
+						User: "ubuntu",
+						Port: 2222,
+						Key:  "~/.ssh/custom_key",
+					},
+				},
+			},
+		},
+		{
+			name: "invalid yaml",
+			input: `
+hosts: [:
+`,
+			wantErr: "yaml:",
+		},
+		{
+			name: "missing host validation error",
+			input: `
+hosts:
+  prod:
+    user: ubuntu
+    key: ~/.ssh/id_rsa
+`,
+			wantErr: `host "prod": missing host`,
+		},
+		{
+			name: "no hosts",
+			input: `
+defaults:
+  key: ~/.ssh/id_rsa
+`,
+			wantErr: "ssh config: no hosts defined",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseSSH([]byte(tt.input))
+
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q got nil", tt.wantErr)
+				}
+
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("expected error containing %q got %q", tt.wantErr, err.Error())
+				}
+
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if !reflect.DeepEqual(tt.want, got) {
+				t.Fatalf("ParseSSH() = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNewSSH(t *testing.T) {
+	t.Run("reads config from file", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "config.yaml")
+
+		data := `
+hosts:
+  prod:
+    host: prod.example.com
+    user: ubuntu
+    key: ~/.ssh/id_rsa
+`
+
+		if err := os.WriteFile(path, []byte(data), 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		cfg, err := NewSSH(path)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if cfg.Hosts["prod"].Host != "prod.example.com" {
+			t.Fatalf("unexpected host: %+v", cfg.Hosts["prod"])
+		}
+	})
+
+	t.Run("missing file returns helpful error", func(t *testing.T) {
+		_, err := NewSSH("/does/not/exist.yaml")
+
+		if err == nil {
+			t.Fatal("expected error")
+		}
+
+		if !strings.Contains(err.Error(), "SSH config not found") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

This PR adds configuration support for SSH log sources through `config.yaml` and improves config loading/validation.

### Changes

- add SSH log configuration support via `config.yaml`
- add `--host` flag for specifying remote SSH host
- add `--config` flag to load a custom config file path
- add config validation for required/invalid fields
- add config defaults:
  - `default.key`
  - SSH port fallback/default handling

### Notes

This enables using `reqlog` against remote SSH log sources with config-driven setup while keeping CLI flags available for overrides.