### PR TITLE
fix(ssh): prevent streaming freeze by closing session without wait

### DIFF
--- a/internal/transport/ssh_executor.go
+++ b/internal/transport/ssh_executor.go
@@ -82,9 +82,6 @@ type SSHReadCloser struct {
 }
 
 func (r *SSHReadCloser) Close() error {
-	waitErr := r.session.Wait()
-
-	_ = r.session.Close()
-
-	return waitErr
+	r.session.Close()
+	return nil
 }


### PR DESCRIPTION
- remove blocking session.Wait() from Close()
- use session.Close() to avoid SSH stream deadlock
- fixes freeze in SSH file logs and docker logs streaming