### PR TITLE
fix(formatter): improve context line dimming and test coverage

### DIFF
--- a/internal/formatter/formatter.go
+++ b/internal/formatter/formatter.go
@@ -111,10 +111,6 @@ func (f *Formatter) outputPretty(entry domain.LogEntry) string {
 
 	msg := f.renderPrettyMessage(entry)
 
-	if entry.IsContext {
-		msg = dim + msg + reset
-	}
-
 	service := entry.Service
 
 	if entry.Host != "" {
@@ -140,47 +136,81 @@ func (f *Formatter) outputPretty(entry domain.LogEntry) string {
 }
 
 func (f *Formatter) renderPrettyMessage(entry domain.LogEntry) string {
-	level, fields := f.renderPrettyFields(entry.Fields)
+	level, fields := f.renderPrettyFields(entry.Fields, entry.IsContext)
 
 	if entry.Message == "" {
 		return fields
 	}
 
-	if fields == "" {
-		return entry.Message
+	message := entry.Message
+	if entry.IsContext {
+		message = dim + entry.Message + reset
+	} else {
+		message = f.colorizer.Bold(entry.Message) + reset
 	}
 
-	return level + " " + f.colorizer.Bold(entry.Message) + reset + " " + fields
+	if fields == "" {
+		return message
+	}
+
+	return strings.TrimSpace(level + " " + message + " " + fields)
 }
 
-func (f *Formatter) renderPrettyFields(fields map[string]any) (string, string) {
-	var kvParts []string
-	var level string
+func (f *Formatter) renderPrettyFields(
+	fields map[string]any,
+	isContext bool,
+) (string, string) {
+	var (
+		kvParts []string
+		level   string
+	)
 
 	for _, pair := range sortKVByPriority(fields) {
 		key := pair.key
 		val := pair.value
 
-		renderedVal := stringifyValue(val)
-
 		if key == "level" {
 			level = f.colorLevel(val)
+			if isContext {
+				level = dim + level + reset
+			}
 			continue
 		}
 
-		key = f.highlightKey(key)
-
 		kvParts = append(
 			kvParts,
-			fmt.Sprintf(
-				"%s=%s",
-				f.colorizer.Cyan(key),
-				renderedVal,
-			),
+			f.renderPrettyField(key, val, isContext),
 		)
 	}
 
 	return level, strings.Join(kvParts, " ")
+}
+
+func (f *Formatter) renderPrettyField(
+	key string,
+	val any,
+	isContext bool,
+) string {
+	renderedVal := stringifyValue(val)
+
+	if isContext {
+		return fmt.Sprintf(
+			"%s%s%s=%s%s",
+			dim,
+			f.colorizer.Cyan(key),
+			dim,
+			dim,
+			renderedVal,
+		)
+	}
+
+	key = f.highlightKey(key)
+
+	return fmt.Sprintf(
+		"%s=%s",
+		f.colorizer.Cyan(key),
+		renderedVal,
+	)
 }
 
 func (f *Formatter) colorLevel(v any) string {

--- a/internal/formatter/formatter_test.go
+++ b/internal/formatter/formatter_test.go
@@ -196,18 +196,62 @@ func TestFormatter_Format_ContextEntry(t *testing.T) {
 	entry := domain.LogEntry{
 		Timestamp: mustParseTime(t, "2024-03-10T12:00:00Z"),
 		Service:   "auth",
-		Message:   "user=123 status=ok",
+		Message:   "request completed",
 		IsContext: true,
+		Fields: map[string]any{
+			"level":      "info",
+			"request_id": "abc123",
+			"status":     "ok",
+		},
 	}
 
 	got := f.Format(entry)
 
-	if !strings.Contains(got, dim) {
-		t.Fatalf("expected formatted output to contain dim ANSI code, got %q", got)
-	}
+	// Level should be dimmed
+	assertContains(
+		t,
+		strings.ToLower(got),
+		"info",
+	)
+	// Message should be dimmed
+	assertContains(
+		t,
+		got,
+		dim+"request completed"+reset,
+	)
 
-	if !strings.Contains(got, "user") {
-		t.Fatalf("expected formatted output to contain message fields, got %q", got)
+	// Fields should be dimmed
+	assertContains(
+		t,
+		got,
+		dim+f.colorizer.Cyan("request_id"),
+	)
+	assertContains(
+		t,
+		got,
+		"="+dim+"abc123",
+	)
+	assertContains(
+		t,
+		got,
+		dim+f.colorizer.Cyan("status"),
+	)
+	assertContains(
+		t,
+		got,
+		"="+dim+"ok",
+	)
+}
+
+func assertContains(t *testing.T, got, want string) {
+	t.Helper()
+
+	if !strings.Contains(got, want) {
+		t.Fatalf(
+			"expected output to contain %q, got %q",
+			want,
+			got,
+		)
 	}
 }
 


### PR DESCRIPTION
This PR improves the visual hierarchy of context lines in pretty log output by ensuring all context elements (level, message, and fields) are properly dimmed. It also strengthens test coverage to accurately validate context formatting behavior.