### PR TITLE
feat(formatter): add --fields support for filtered log output

### DIFF
--- a/internal/app/run.go
+++ b/internal/app/run.go
@@ -66,6 +66,7 @@ func Run(ctx context.Context, cfg *config.Config) error {
 		SearchKeys: cfg.Keys,
 		Output:     cfg.Output,
 		Context:    cfg.Context,
+		Fields:     cfg.Fields,
 	})
 
 	for _, e := range allEntries {

--- a/internal/cli/flags.go
+++ b/internal/cli/flags.go
@@ -16,6 +16,7 @@ type flagOptions struct {
 	output  string
 	format  string
 	config  string
+	fields  string
 }
 
 func ParseConfig() (*config.Config, error) {
@@ -170,6 +171,14 @@ func registerFlags(cfg *config.Config) *flagOptions {
 		"SSH host alias from config file",
 	)
 
+	stringFlag(
+		&opts.fields,
+		"fields",
+		"",
+		"",
+		"display only selected fields (comma-separated, e.g. request_id,path,status)",
+	)
+
 	return opts
 }
 
@@ -194,6 +203,10 @@ func applyDerivedConfig(cfg *config.Config, opts *flagOptions) error {
 		if err != nil {
 			return err
 		}
+	}
+
+	if opts.fields != "" {
+		cfg.Fields = strings.Split(opts.fields, ",")
 	}
 
 	return nil

--- a/internal/cli/flags_test.go
+++ b/internal/cli/flags_test.go
@@ -85,6 +85,7 @@ func TestApplyDerivedConfig(t *testing.T) {
 			source:  "docker",
 			output:  "json",
 			format:  "text",
+			fields:  "request_id,status",
 		}
 
 		err := applyDerivedConfig(cfg, opts)
@@ -110,6 +111,10 @@ func TestApplyDerivedConfig(t *testing.T) {
 
 		if cfg.Format != config.FormatText {
 			t.Fatalf("format: expected %v got %v", config.FormatText, cfg.Format)
+		}
+
+		if !reflect.DeepEqual(cfg.Fields, []string{"request_id", "status"}) {
+			t.Fatalf("fields: expected %v got %v", []string{"request_id", "status"}, cfg.Fields)
 		}
 	})
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -34,6 +34,7 @@ type Config struct {
 	Services    []string
 	Latest      bool
 	Context     int
+	Fields      []string
 
 	Source Source
 	Follow bool

--- a/internal/formatter/formatter.go
+++ b/internal/formatter/formatter.go
@@ -20,6 +20,7 @@ type Formatter struct {
 	searchKeys   []string
 	output       config.OutputFormat
 	context      int
+	fields       []string
 }
 
 type Opts struct {
@@ -27,6 +28,7 @@ type Opts struct {
 	SearchKeys []string
 	Output     config.OutputFormat
 	Context    int
+	Fields     []string
 }
 
 func NewFormatter(opts *Opts) *Formatter {
@@ -43,6 +45,7 @@ func NewFormatter(opts *Opts) *Formatter {
 		searchKeys:   opts.SearchKeys,
 		output:       opts.Output,
 		context:      opts.Context,
+		fields:       opts.Fields,
 	}
 }
 
@@ -67,6 +70,10 @@ func (f *Formatter) Format(entry domain.LogEntry) string {
 }
 
 func (f *Formatter) outputJSON(entry domain.LogEntry) string {
+	if len(f.fields) > 0 {
+		return f.outputJSONFields(entry)
+	}
+
 	out := make(map[string]any, len(entry.Fields)+6)
 
 	out["timestamp"] = entry.Timestamp.Format(time.RFC3339Nano)
@@ -90,19 +97,50 @@ func (f *Formatter) outputJSON(entry domain.LogEntry) string {
 		}
 	}
 
-	b, err := json.Marshal(out)
-	if err == nil {
-		return string(b)
+	return marshal(out, entry)
+}
+
+func (f *Formatter) outputJSONFields(
+	entry domain.LogEntry,
+) string {
+	out := make(map[string]any, len(f.fields))
+
+	for _, k := range f.fields {
+		switch k {
+		case "timestamp":
+			out[k] = entry.Timestamp.Format(time.RFC3339Nano)
+
+		case "service":
+			out[k] = entry.Service
+
+		case "message":
+			out[k] = entry.Message
+
+		case "context":
+			if f.context > 0 {
+				out[k] = entry.IsContext
+			}
+
+		case "host":
+			if entry.Host != "" {
+				out[k] = entry.Host
+			}
+
+		default:
+			fieldKey := k
+
+			// allow "fields." prefix to explicitly access fields
+			// when there's a name conflict with core keys
+			if after, ok := strings.CutPrefix(k, "fields."); ok {
+				fieldKey = after
+			}
+			if val, ok := entry.Fields[fieldKey]; ok {
+				out[k] = val
+			}
+		}
 	}
 
-	errorOut := map[string]any{
-		"error":   "failed to marshal log entry",
-		"details": err.Error(),
-		"raw":     entry.Raw,
-	}
-
-	fallback, _ := json.Marshal(errorOut)
-	return string(fallback)
+	return marshal(out, entry)
 }
 
 func (f *Formatter) outputPretty(entry domain.LogEntry) string {
@@ -136,7 +174,7 @@ func (f *Formatter) outputPretty(entry domain.LogEntry) string {
 }
 
 func (f *Formatter) renderPrettyMessage(entry domain.LogEntry) string {
-	level, fields := f.renderPrettyFields(entry.Fields, entry.IsContext)
+	level, fields := f.renderPrettyFields(entry.Fields, entry.IsContext, f.fields)
 
 	if entry.Message == "" {
 		return fields
@@ -149,37 +187,62 @@ func (f *Formatter) renderPrettyMessage(entry domain.LogEntry) string {
 		message = f.colorizer.Bold(entry.Message) + reset
 	}
 
-	if fields == "" {
-		return message
-	}
-
 	return strings.TrimSpace(level + " " + message + " " + fields)
 }
 
 func (f *Formatter) renderPrettyFields(
 	fields map[string]any,
 	isContext bool,
+	fieldsToInclude []string,
 ) (string, string) {
 	var (
 		kvParts []string
 		level   string
 	)
 
-	for _, pair := range sortKVByPriority(fields) {
-		key := pair.key
-		val := pair.value
+	if val, ok := fields["level"]; ok {
+		level = f.colorLevel(val)
 
-		if key == "level" {
-			level = f.colorLevel(val)
-			if isContext {
-				level = dim + level + reset
+		if isContext {
+			level = dim + level + reset
+		}
+	}
+
+	kvParts = make([]string, 0, len(fields))
+
+	// Respect --fields order
+	if len(fieldsToInclude) > 0 {
+		for _, key := range fieldsToInclude {
+			val, ok := fields[key]
+			if !ok || key == "level" {
+				continue
 			}
+
+			kvParts = append(
+				kvParts,
+				f.renderPrettyField(key, val, isContext),
+			)
+		}
+
+		return level, strings.Join(kvParts, " ")
+	}
+
+	keys := make([]string, 0, len(fields))
+
+	for key := range fields {
+		if key == "level" {
 			continue
 		}
 
+		keys = append(keys, key)
+	}
+
+	sort.Strings(keys)
+
+	for _, key := range keys {
 		kvParts = append(
 			kvParts,
-			f.renderPrettyField(key, val, isContext),
+			f.renderPrettyField(key, fields[key], isContext),
 		)
 	}
 
@@ -236,46 +299,6 @@ func (f *Formatter) highlightKey(key string) string {
 	return key
 }
 
-type kv struct {
-	key   string
-	value any
-}
-
-func sortKVByPriority(fields map[string]any) []kv {
-	pairs := make([]kv, 0, len(fields))
-
-	for k, v := range fields {
-		pairs = append(pairs, kv{
-			key:   k,
-			value: v,
-		})
-	}
-
-	priority := func(key string) int {
-		switch key {
-		case "level":
-			return 1
-		case "request_id":
-			return 2
-		default:
-			return 99
-		}
-	}
-
-	sort.SliceStable(pairs, func(i, j int) bool {
-		pi := priority(pairs[i].key)
-		pj := priority(pairs[j].key)
-
-		if pi != pj {
-			return pi < pj
-		}
-
-		return pairs[i].key < pairs[j].key
-	})
-
-	return pairs
-}
-
 func stringifyValue(v any) string {
 	switch val := v.(type) {
 	case string:
@@ -291,4 +314,20 @@ func stringifyValue(v any) string {
 		}
 		return string(b)
 	}
+}
+
+func marshal(out any, entry domain.LogEntry) string {
+	b, err := json.Marshal(out)
+	if err == nil {
+		return string(b)
+	}
+
+	errorOut := map[string]any{
+		"error":   "failed to marshal log entry",
+		"details": err.Error(),
+		"raw":     entry.Raw,
+	}
+
+	fallback, _ := json.Marshal(errorOut)
+	return string(fallback)
 }

--- a/internal/formatter/formatter_test.go
+++ b/internal/formatter/formatter_test.go
@@ -2,7 +2,6 @@ package formatter
 
 import (
 	"encoding/json"
-	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -132,69 +131,13 @@ func TestFormat_OutputStructure_WithHost(t *testing.T) {
 	}
 }
 
-func TestSortKVByPriority(t *testing.T) {
-	tests := []struct {
-		name     string
-		input    map[string]any
-		expected []kv
-	}{
-		{
-			name: "prioritizes level then request_id",
-			input: map[string]any{
-				"extra":      "foo",
-				"request_id": "abc",
-				"level":      "warn",
-			},
-			expected: []kv{
-				{key: "level", value: "warn"},
-				{key: "request_id", value: "abc"},
-				{key: "extra", value: "foo"},
-			},
-		},
-		{
-			name: "alphabetical fallback for equal priority",
-			input: map[string]any{
-				"zeta":  "1",
-				"alpha": "2",
-			},
-			expected: []kv{
-				{key: "alpha", value: "2"},
-				{key: "zeta", value: "1"},
-			},
-		},
-		{
-			name: "mixed priority and alphabetical",
-			input: map[string]any{
-				"beta":       "b",
-				"level":      "info",
-				"request_id": "r1",
-				"alpha":      "a",
-			}, expected: []kv{
-				{key: "level", value: "info"},
-				{key: "request_id", value: "r1"},
-				{key: "alpha", value: "a"},
-				{key: "beta", value: "b"},
-			},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := sortKVByPriority(tt.input)
-			if !reflect.DeepEqual(got, tt.expected) {
-				t.Errorf("got %v; want %v", got, tt.expected)
-			}
-		})
-	}
-}
-
 func TestFormatter_Format_ContextEntry(t *testing.T) {
 	f := NewFormatter(&Opts{
 		Output: config.OutputPretty,
 	})
 
 	entry := domain.LogEntry{
-		Timestamp: mustParseTime(t, "2024-03-10T12:00:00Z"),
+		Timestamp: mustParseRFC3339(t, "2024-03-10T12:00:00Z"),
 		Service:   "auth",
 		Message:   "request completed",
 		IsContext: true,
@@ -243,29 +186,6 @@ func TestFormatter_Format_ContextEntry(t *testing.T) {
 	)
 }
 
-func assertContains(t *testing.T, got, want string) {
-	t.Helper()
-
-	if !strings.Contains(got, want) {
-		t.Fatalf(
-			"expected output to contain %q, got %q",
-			want,
-			got,
-		)
-	}
-}
-
-func mustParseTime(t *testing.T, s string) time.Time {
-	t.Helper()
-
-	ts, err := time.Parse(time.RFC3339, s)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	return ts
-}
-
 func TestFormatter_OutputJSON(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -276,7 +196,7 @@ func TestFormatter_OutputJSON(t *testing.T) {
 		{
 			name: "basic json output",
 			entry: domain.LogEntry{
-				Timestamp: mustParseRFC3339("2024-03-10T12:00:00Z"),
+				Timestamp: mustParseRFC3339(t, "2024-03-10T12:00:00Z"),
 				Service:   "auth",
 				Message:   "login success",
 				Fields: map[string]any{
@@ -305,7 +225,7 @@ func TestFormatter_OutputJSON(t *testing.T) {
 		{
 			name: "context flag is included",
 			entry: domain.LogEntry{
-				Timestamp: mustParseRFC3339("2024-03-10T12:00:00Z"),
+				Timestamp: mustParseRFC3339(t, "2024-03-10T12:00:00Z"),
 				Service:   "auth",
 				Message:   "login",
 				IsContext: true,
@@ -321,7 +241,7 @@ func TestFormatter_OutputJSON(t *testing.T) {
 		{
 			name: "reserved keys are prefixed into fields.*",
 			entry: domain.LogEntry{
-				Timestamp: mustParseRFC3339("2024-03-10T12:00:00Z"),
+				Timestamp: mustParseRFC3339(t, "2024-03-10T12:00:00Z"),
 				Service:   "auth",
 				Message:   "test",
 				Fields: map[string]any{
@@ -355,7 +275,7 @@ func TestFormatter_OutputJSON(t *testing.T) {
 		{
 			name: "multiple fields preserved",
 			entry: domain.LogEntry{
-				Timestamp: mustParseRFC3339("2024-03-10T12:00:00Z"),
+				Timestamp: mustParseRFC3339(t, "2024-03-10T12:00:00Z"),
 				Service:   "svc",
 				Message:   "ok",
 				Fields: map[string]any{
@@ -439,10 +359,316 @@ func TestFormatter_OutputJSON_MarshalError(t *testing.T) {
 	}
 }
 
-func mustParseRFC3339(s string) time.Time {
-	t, err := time.Parse(time.RFC3339Nano, s)
-	if err != nil {
-		panic(err)
+func TestFormatter_OutputJSONFields(t *testing.T) {
+	ts := time.Date(2026, 3, 20, 14, 10, 0, 0, time.UTC)
+
+	tests := []struct {
+		name   string
+		fields []string
+		entry  domain.LogEntry
+		assert func(t *testing.T, m map[string]any)
+	}{
+		{
+			name:   "full json output",
+			fields: nil,
+			entry: domain.LogEntry{
+				Timestamp: ts,
+				Service:   "api",
+				Message:   "hello",
+				Host:      "srv1",
+				IsContext: true,
+				Fields: map[string]any{
+					"request_id": "req-123",
+				},
+			},
+			assert: func(t *testing.T, m map[string]any) {
+				if m["timestamp"] != ts.Format(time.RFC3339Nano) {
+					t.Fatalf("unexpected timestamp: %v", m["timestamp"])
+				}
+
+				if m["service"] != "api" {
+					t.Fatalf("unexpected service: %v", m["service"])
+				}
+
+				if m["message"] != "hello" {
+					t.Fatalf("unexpected message: %v", m["message"])
+				}
+
+				if m["host"] != "srv1" {
+					t.Fatalf("unexpected host: %v", m["host"])
+				}
+
+				if m["request_id"] != "req-123" {
+					t.Fatalf("unexpected request_id: %v", m["request_id"])
+				}
+
+				if m["context"] != true {
+					t.Fatalf("unexpected context: %v", m["context"])
+				}
+			},
+		},
+		{
+			name:   "selected fields output",
+			fields: []string{"timestamp", "service", "request_id"},
+			entry: domain.LogEntry{
+				Timestamp: ts,
+				Service:   "api",
+				Message:   "ignored",
+				Fields: map[string]any{
+					"request_id": "req-123",
+					"level":      "warn",
+				},
+			},
+			assert: func(t *testing.T, m map[string]any) {
+				if len(m) != 3 {
+					t.Fatalf("expected 3 fields, got %d: %#v", len(m), m)
+				}
+
+				if m["timestamp"] != ts.Format(time.RFC3339Nano) {
+					t.Fatalf("unexpected timestamp")
+				}
+
+				if m["service"] != "api" {
+					t.Fatalf("unexpected service")
+				}
+
+				if m["request_id"] != "req-123" {
+					t.Fatalf("unexpected request_id")
+				}
+
+				if _, ok := m["message"]; ok {
+					t.Fatalf("message should not be included")
+				}
+			},
+		},
+		{
+			name:   "fields prefix accesses conflicting field names",
+			fields: []string{"timestamp", "fields.timestamp", "service", "fields.service", "message", "context", "fields.context", "host", "fields.host"},
+			entry: domain.LogEntry{
+				Timestamp: ts,
+				Service:   "api",
+				IsContext: true,
+				Host:      "srv",
+				Fields: map[string]any{
+					"timestamp": "field-ts",
+					"service":   "field-service",
+					"context":   "field-context",
+					"host":      "field-host",
+				},
+			},
+			assert: func(t *testing.T, m map[string]any) {
+				if m["timestamp"] != ts.Format(time.RFC3339Nano) {
+					t.Fatalf("unexpected timestamp: %v", m["timestamp"])
+				}
+
+				if m["service"] != "api" {
+					t.Fatalf("unexpected service: %v", m["service"])
+				}
+
+				if m["fields.timestamp"] != "field-ts" {
+					t.Fatalf("unexpected fields.timestamp: %v", m["fields.timestamp"])
+				}
+
+				if m["fields.service"] != "field-service" {
+					t.Fatalf("unexpected fields.service: %v", m["fields.service"])
+				}
+
+				if m["context"] != true {
+					t.Fatalf("unexpected context: %v", m["context"])
+				}
+
+				if m["fields.context"] != "field-context" {
+					t.Fatalf("unexpected fields.context: %v", m["fields.context"])
+				}
+
+				if m["host"] != "srv" {
+					t.Fatalf("unexpected host: %v", m["host"])
+				}
+
+				if m["fields.host"] != "field-host" {
+					t.Fatalf("unexpected fields.host: %v", m["fields.host"])
+				}
+			},
+		},
 	}
-	return t
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := NewFormatter(&Opts{
+				Output:  config.OutputJSON,
+				Fields:  tt.fields,
+				Context: 1,
+			})
+
+			out := f.Format(tt.entry)
+
+			var decoded map[string]any
+			if err := json.Unmarshal([]byte(out), &decoded); err != nil {
+				t.Fatalf("invalid json: %v\n%s", err, out)
+			}
+
+			tt.assert(t, decoded)
+		})
+	}
+}
+
+func TestFormatter_RenderPrettyFields(t *testing.T) {
+	tests := []struct {
+		name            string
+		fields          map[string]any
+		fieldsToInclude []string
+
+		wantLevel       bool
+		wantContains    []string
+		wantNotContains []string
+		wantOrder       []string
+	}{
+		{
+			name: "sorted fields and level extraction",
+			fields: map[string]any{
+				"request_id": "abc",
+				"user":       "123",
+				"level":      "info",
+			},
+			wantLevel: true,
+			wantContains: []string{
+				"request_id",
+				"user",
+			},
+			wantOrder: []string{
+				"request_id",
+				"user",
+			},
+		},
+		{
+			name: "respects fields order",
+			fields: map[string]any{
+				"user":       "123",
+				"request_id": "abc",
+				"trace_id":   "xyz",
+			},
+			fieldsToInclude: []string{
+				"trace_id",
+				"user",
+			},
+			wantContains: []string{
+				"trace_id",
+				"user",
+			},
+			wantNotContains: []string{
+				"request_id",
+			},
+			wantOrder: []string{
+				"trace_id",
+				"user",
+			},
+		},
+		{
+			name: "level skipped from included fields",
+			fields: map[string]any{
+				"level": "error",
+				"user":  "123",
+			},
+			fieldsToInclude: []string{
+				"level",
+				"user",
+			},
+			wantLevel: true,
+			wantContains: []string{
+				"user",
+			},
+			wantNotContains: []string{
+				"level",
+			},
+		},
+		{
+			name: "missing requested fields ignored",
+			fields: map[string]any{
+				"user": "123",
+			},
+			fieldsToInclude: []string{
+				"trace_id",
+				"user",
+			},
+			wantContains: []string{
+				"user",
+			},
+			wantNotContains: []string{
+				"trace_id",
+			},
+		},
+	}
+
+	f := NewFormatter(&Opts{})
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			level, out := f.renderPrettyFields(
+				tt.fields,
+				false,
+				tt.fieldsToInclude,
+			)
+
+			if tt.wantLevel && level == "" {
+				t.Fatal("expected level output")
+			}
+
+			if !tt.wantLevel && level != "" {
+				t.Fatalf("expected no level, got %q", level)
+			}
+
+			for _, s := range tt.wantContains {
+				if !strings.Contains(out, s) {
+					t.Fatalf("expected %q in output: %q", s, out)
+				}
+			}
+
+			for _, s := range tt.wantNotContains {
+				if strings.Contains(out, s) {
+					t.Fatalf("did not expect %q in output: %q", s, out)
+				}
+			}
+
+			for i := 0; i < len(tt.wantOrder)-1; i++ {
+				left := strings.Index(out, tt.wantOrder[i])
+				right := strings.Index(out, tt.wantOrder[i+1])
+
+				if left == -1 || right == -1 {
+					t.Fatalf("order check failed: %q", out)
+				}
+
+				if left > right {
+					t.Fatalf(
+						"expected %q before %q in %q",
+						tt.wantOrder[i],
+						tt.wantOrder[i+1],
+						out,
+					)
+				}
+			}
+		})
+	}
+}
+
+func assertContains(t *testing.T, got, want string) {
+	t.Helper()
+
+	if !strings.Contains(got, want) {
+		t.Fatalf(
+			"expected output to contain %q, got %q",
+			want,
+			got,
+		)
+	}
+}
+
+func mustParseRFC3339(t *testing.T, s string) time.Time {
+	t.Helper()
+
+	ts, err := time.Parse(time.RFC3339Nano, s)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return ts
 }


### PR DESCRIPTION
## Summary

This PR adds support for the `--fields` flag to reduce noisy log output by displaying only selected fields during debugging and tracing.

The feature works across both JSON and pretty output formats while preserving readability and existing behavior.

## Changes

### `--fields` flag

Added support for filtering output to selected fields:

```bash
reqlog --fields request_id,path,status
```

### JSON Output

- Supports filtering any available field
- Includes support for reserved/collision-prefixed fields such as `fields.service`
- Maintains existing JSON output behavior when `--fields` is not provided

Example:

```bash
reqlog --output json --fields timestamp,message,request_id
```

### Pretty Output

- Supports filtering structured log fields
- Preserves field order based on user input
- Keeps core output structure mandatory for readability:
  - timestamp
  - service
  - message
  - host
  - context

This ensures pretty output continues to function as a readable timeline across services.

Example:

```bash
reqlog --fields request_id,path
```

Output:

```text
2026-04-28T10:00:01.100Z [api-gateway] | INFO Request received request_id=req-1001 path=/login
```

### Cleanup

- Removed unused `sortKVByPriority` helper from formatter
- Removed duplicate `mustParseTime` formatter test helper
- Simplified formatter logic
