### PR TITLE
feat: add verbose diagnostics output

### DIFF
--- a/internal/app/run.go
+++ b/internal/app/run.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/sagarmaheshwary/reqlog/internal/config"
+	"github.com/sagarmaheshwary/reqlog/internal/diagnostics"
 	"github.com/sagarmaheshwary/reqlog/internal/domain"
 	"github.com/sagarmaheshwary/reqlog/internal/formatter"
 	"github.com/sagarmaheshwary/reqlog/internal/scanner"
@@ -16,8 +17,9 @@ import (
 
 func Run(ctx context.Context, cfg *config.Config) error {
 	lp := newLineProcessor(cfg)
+	dg := diagnostics.NewDiagnostics()
 
-	scannerSources, err := scannersForConfig(cfg, lp)
+	scannerSources, err := scannersForConfig(cfg, lp, dg)
 	if err != nil {
 		return err
 	}
@@ -59,6 +61,10 @@ func Run(ctx context.Context, cfg *config.Config) error {
 		}
 
 		allEntries = allEntries[start:end]
+	}
+
+	if cfg.Verbose {
+		allEntries = append(allEntries, dg.Entries()...)
 	}
 
 	f := formatter.NewFormatter(&formatter.Opts{
@@ -115,13 +121,14 @@ func resolveSource(
 	return sources, nil
 }
 
-func scannersForConfig(cfg *config.Config, lp *scanner.LineProcessor) ([]scannerSource, error) {
+func scannersForConfig(cfg *config.Config, lp *scanner.LineProcessor, dg *diagnostics.Diagnostics) ([]scannerSource, error) {
 	if cfg.Host == "" {
 		scn, err := scanner.New(&scanner.FactoryOpts{
 			Source:        cfg.Source,
 			LineProcessor: lp,
 			Executor:      transport.NewExecutor(nil),
 			LogFileReader: transport.NewLogFileReader(nil),
+			Diagnostics:   dg,
 		})
 		if err != nil {
 			return nil, err
@@ -151,6 +158,7 @@ func scannersForConfig(cfg *config.Config, lp *scanner.LineProcessor) ([]scanner
 			Executor:      executor,
 			LogFileReader: transport.NewLogFileReader(executor),
 			Host:          host,
+			Diagnostics:   dg,
 		})
 		if err != nil {
 			return nil, err

--- a/internal/app/run_test.go
+++ b/internal/app/run_test.go
@@ -95,7 +95,7 @@ func TestScannersForConfig_Local(t *testing.T) {
 
 	lp := newLineProcessor(cfg)
 
-	got, err := scannersForConfig(cfg, lp)
+	got, err := scannersForConfig(cfg, lp, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -119,7 +119,7 @@ func TestScannersForConfig_InvalidHost(t *testing.T) {
 
 	lp := newLineProcessor(cfg)
 
-	_, err := scannersForConfig(cfg, lp)
+	_, err := scannersForConfig(cfg, lp, nil)
 	if err == nil {
 		t.Fatal("expected error")
 	}

--- a/internal/cli/flags.go
+++ b/internal/cli/flags.go
@@ -179,6 +179,14 @@ func registerFlags(cfg *config.Config) *flagOptions {
 		"display only selected fields (comma-separated, e.g. request_id,path,status)",
 	)
 
+	boolFlag(
+		&cfg.Verbose,
+		"verbose",
+		"V",
+		false,
+		"show warnings and errors encountered during scanning",
+	)
+
 	return opts
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -35,6 +35,7 @@ type Config struct {
 	Latest      bool
 	Context     int
 	Fields      []string
+	Verbose     bool
 
 	Source Source
 	Follow bool

--- a/internal/diagnostics/diagnostics.go
+++ b/internal/diagnostics/diagnostics.go
@@ -1,0 +1,53 @@
+package diagnostics
+
+import (
+	"time"
+
+	"github.com/sagarmaheshwary/reqlog/internal/domain"
+)
+
+const service = "reqlog"
+
+type Diagnostics struct {
+	items []domain.LogEntry
+}
+
+func NewDiagnostics() *Diagnostics {
+	return &Diagnostics{
+		items: make([]domain.LogEntry, 0),
+	}
+}
+
+func (d *Diagnostics) Error(msg string, fields map[string]any) {
+	if fields == nil {
+		fields = make(map[string]any, 1)
+	}
+	fields["level"] = "error"
+
+	d.items = append(d.items, domain.LogEntry{
+		Service:       service,
+		Message:       msg,
+		Fields:        fields,
+		Timestamp:     time.Now().UTC(),
+		IsDiagnostics: true,
+	})
+}
+
+func (d *Diagnostics) Warn(msg string, fields map[string]any) {
+	if fields == nil {
+		fields = make(map[string]any, 1)
+	}
+	fields["level"] = "warn"
+
+	d.items = append(d.items, domain.LogEntry{
+		Service:       service,
+		Message:       msg,
+		Fields:        fields,
+		Timestamp:     time.Now().UTC(),
+		IsDiagnostics: true,
+	})
+}
+
+func (d *Diagnostics) Entries() []domain.LogEntry {
+	return d.items
+}

--- a/internal/diagnostics/diagnostics_test.go
+++ b/internal/diagnostics/diagnostics_test.go
@@ -1,0 +1,131 @@
+package diagnostics
+
+import (
+	"testing"
+	"time"
+)
+
+func TestDiagnostics_LogEntries(t *testing.T) {
+	tests := []struct {
+		name      string
+		logFn     func(*Diagnostics)
+		wantLevel string
+	}{
+		{
+			name: "error",
+			logFn: func(d *Diagnostics) {
+				d.Error("something failed", map[string]any{
+					"path": "/tmp/app.log",
+				})
+			},
+			wantLevel: "error",
+		},
+		{
+			name: "warn",
+			logFn: func(d *Diagnostics) {
+				d.Warn("something suspicious", map[string]any{
+					"path": "/tmp/app.log",
+				})
+			},
+			wantLevel: "warn",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := NewDiagnostics()
+
+			before := time.Now().UTC()
+
+			tt.logFn(d)
+
+			after := time.Now().UTC()
+
+			entries := d.Entries()
+
+			if len(entries) != 1 {
+				t.Fatalf("expected 1 entry, got %d", len(entries))
+			}
+
+			entry := entries[0]
+
+			if entry.Service != service {
+				t.Fatalf("expected service %q got %q", service, entry.Service)
+			}
+
+			if !entry.IsDiagnostics {
+				t.Fatal("expected IsDiagnostics=true")
+			}
+
+			if entry.Fields["level"] != tt.wantLevel {
+				t.Fatalf(
+					"expected level %q got %v",
+					tt.wantLevel,
+					entry.Fields["level"],
+				)
+			}
+
+			if entry.Fields["path"] != "/tmp/app.log" {
+				t.Fatalf(
+					"expected path field, got %v",
+					entry.Fields["path"],
+				)
+			}
+
+			if entry.Timestamp.Before(before) ||
+				entry.Timestamp.After(after) {
+				t.Fatalf(
+					"timestamp %v outside expected range [%v, %v]",
+					entry.Timestamp,
+					before,
+					after,
+				)
+			}
+		})
+	}
+}
+
+func TestDiagnostics_NilFields(t *testing.T) {
+	tests := []struct {
+		name      string
+		logFn     func(*Diagnostics)
+		wantLevel string
+	}{
+		{
+			name: "error",
+			logFn: func(d *Diagnostics) {
+				d.Error("failed", nil)
+			},
+			wantLevel: "error",
+		},
+		{
+			name: "warn",
+			logFn: func(d *Diagnostics) {
+				d.Warn("warning", nil)
+			},
+			wantLevel: "warn",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := NewDiagnostics()
+
+			tt.logFn(d)
+
+			entry := d.Entries()[0]
+
+			if entry.Fields == nil {
+				t.Fatal("fields should not be nil")
+			}
+
+			if entry.Fields["level"] != tt.wantLevel {
+				t.Fatalf(
+					"expected level %q got %v",
+					tt.wantLevel,
+					entry.Fields["level"],
+				)
+			}
+		})
+	}
+}

--- a/internal/domain/logentry.go
+++ b/internal/domain/logentry.go
@@ -3,11 +3,12 @@ package domain
 import "time"
 
 type LogEntry struct {
-	Timestamp time.Time
-	Service   string
-	Message   string
-	IsContext bool
-	Fields    map[string]any
-	Raw       string
-	Host      string
+	Timestamp     time.Time
+	Service       string
+	Message       string
+	IsContext     bool
+	IsDiagnostics bool
+	Fields        map[string]any
+	Raw           string
+	Host          string
 }

--- a/internal/formatter/formatter.go
+++ b/internal/formatter/formatter.go
@@ -70,7 +70,7 @@ func (f *Formatter) Format(entry domain.LogEntry) string {
 }
 
 func (f *Formatter) outputJSON(entry domain.LogEntry) string {
-	if len(f.fields) > 0 {
+	if len(f.fields) > 0 && !entry.IsDiagnostics {
 		return f.outputJSONFields(entry)
 	}
 
@@ -174,7 +174,7 @@ func (f *Formatter) outputPretty(entry domain.LogEntry) string {
 }
 
 func (f *Formatter) renderPrettyMessage(entry domain.LogEntry) string {
-	level, fields := f.renderPrettyFields(entry.Fields, entry.IsContext, f.fields)
+	level, fields := f.renderPrettyFields(entry)
 
 	if entry.Message == "" {
 		return fields
@@ -190,46 +190,42 @@ func (f *Formatter) renderPrettyMessage(entry domain.LogEntry) string {
 	return strings.TrimSpace(level + " " + message + " " + fields)
 }
 
-func (f *Formatter) renderPrettyFields(
-	fields map[string]any,
-	isContext bool,
-	fieldsToInclude []string,
-) (string, string) {
+func (f *Formatter) renderPrettyFields(entry domain.LogEntry) (string, string) {
 	var (
 		kvParts []string
 		level   string
 	)
 
-	if val, ok := fields["level"]; ok {
+	if val, ok := entry.Fields["level"]; ok {
 		level = f.colorLevel(val)
 
-		if isContext {
+		if entry.IsContext {
 			level = dim + level + reset
 		}
 	}
 
-	kvParts = make([]string, 0, len(fields))
+	kvParts = make([]string, 0, len(entry.Fields))
 
 	// Respect --fields order
-	if len(fieldsToInclude) > 0 {
-		for _, key := range fieldsToInclude {
-			val, ok := fields[key]
+	if len(f.fields) > 0 && !entry.IsDiagnostics {
+		for _, key := range f.fields {
+			val, ok := entry.Fields[key]
 			if !ok || key == "level" {
 				continue
 			}
 
 			kvParts = append(
 				kvParts,
-				f.renderPrettyField(key, val, isContext),
+				f.renderPrettyField(key, val, entry.IsContext),
 			)
 		}
 
 		return level, strings.Join(kvParts, " ")
 	}
 
-	keys := make([]string, 0, len(fields))
+	keys := make([]string, 0, len(entry.Fields))
 
-	for key := range fields {
+	for key := range entry.Fields {
 		if key == "level" {
 			continue
 		}
@@ -242,7 +238,7 @@ func (f *Formatter) renderPrettyFields(
 	for _, key := range keys {
 		kvParts = append(
 			kvParts,
-			f.renderPrettyField(key, fields[key], isContext),
+			f.renderPrettyField(key, entry.Fields[key], entry.IsContext),
 		)
 	}
 

--- a/internal/formatter/formatter_test.go
+++ b/internal/formatter/formatter_test.go
@@ -514,9 +514,10 @@ func TestFormatter_OutputJSONFields(t *testing.T) {
 
 func TestFormatter_RenderPrettyFields(t *testing.T) {
 	tests := []struct {
-		name            string
-		fields          map[string]any
-		fieldsToInclude []string
+		name string
+
+		entry  domain.LogEntry
+		fields []string
 
 		wantLevel       bool
 		wantContains    []string
@@ -525,10 +526,12 @@ func TestFormatter_RenderPrettyFields(t *testing.T) {
 	}{
 		{
 			name: "sorted fields and level extraction",
-			fields: map[string]any{
-				"request_id": "abc",
-				"user":       "123",
-				"level":      "info",
+			entry: domain.LogEntry{
+				Fields: map[string]any{
+					"request_id": "abc",
+					"user":       "123",
+					"level":      "info",
+				},
 			},
 			wantLevel: true,
 			wantContains: []string{
@@ -542,12 +545,14 @@ func TestFormatter_RenderPrettyFields(t *testing.T) {
 		},
 		{
 			name: "respects fields order",
-			fields: map[string]any{
-				"user":       "123",
-				"request_id": "abc",
-				"trace_id":   "xyz",
+			entry: domain.LogEntry{
+				Fields: map[string]any{
+					"user":       "123",
+					"request_id": "abc",
+					"trace_id":   "xyz",
+				},
 			},
-			fieldsToInclude: []string{
+			fields: []string{
 				"trace_id",
 				"user",
 			},
@@ -565,11 +570,13 @@ func TestFormatter_RenderPrettyFields(t *testing.T) {
 		},
 		{
 			name: "level skipped from included fields",
-			fields: map[string]any{
-				"level": "error",
-				"user":  "123",
+			entry: domain.LogEntry{
+				Fields: map[string]any{
+					"level": "error",
+					"user":  "123",
+				},
 			},
-			fieldsToInclude: []string{
+			fields: []string{
 				"level",
 				"user",
 			},
@@ -583,10 +590,12 @@ func TestFormatter_RenderPrettyFields(t *testing.T) {
 		},
 		{
 			name: "missing requested fields ignored",
-			fields: map[string]any{
-				"user": "123",
+			entry: domain.LogEntry{
+				Fields: map[string]any{
+					"user": "123",
+				},
 			},
-			fieldsToInclude: []string{
+			fields: []string{
 				"trace_id",
 				"user",
 			},
@@ -597,17 +606,32 @@ func TestFormatter_RenderPrettyFields(t *testing.T) {
 				"trace_id",
 			},
 		},
+		{
+			name: "diagnostics ignores fields filter",
+			entry: domain.LogEntry{
+				IsDiagnostics: true,
+				Fields: map[string]any{
+					"user":       "123",
+					"request_id": "abc",
+				},
+			},
+			fields: []string{
+				"user",
+			},
+			wantContains: []string{
+				"user",
+				"request_id",
+			},
+		},
 	}
-
-	f := NewFormatter(&Opts{})
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			level, out := f.renderPrettyFields(
-				tt.fields,
-				false,
-				tt.fieldsToInclude,
-			)
+			f := NewFormatter(&Opts{
+				Fields: tt.fields,
+			})
+
+			level, out := f.renderPrettyFields(tt.entry)
 
 			if tt.wantLevel && level == "" {
 				t.Fatal("expected level output")

--- a/internal/scanner/docker_scanner.go
+++ b/internal/scanner/docker_scanner.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/sagarmaheshwary/reqlog/internal/diagnostics"
 	"github.com/sagarmaheshwary/reqlog/internal/docker"
 	"github.com/sagarmaheshwary/reqlog/internal/domain"
 	"github.com/sagarmaheshwary/reqlog/internal/formatter"
@@ -18,28 +19,28 @@ type DockerScanner struct {
 	lineProcessor *LineProcessor
 	dockerClient  docker.DockerClient
 	out           io.Writer
-	errOut        io.Writer
 	now           time.Time
 	host          string
+	diagnostics   *diagnostics.Diagnostics
 }
 
 type DockerScannerOpts struct {
 	LineProcessor *LineProcessor
-	dockerClient  docker.DockerClient
+	DockerClient  docker.DockerClient
 	Out           io.Writer
-	ErrOut        io.Writer
 	Now           time.Time
 	Host          string
+	Diagnostics   *diagnostics.Diagnostics
 }
 
 func NewDockerScanner(opts *DockerScannerOpts) *DockerScanner {
 	return &DockerScanner{
 		lineProcessor: opts.LineProcessor,
-		dockerClient:  opts.dockerClient,
+		dockerClient:  opts.DockerClient,
 		out:           opts.Out,
-		errOut:        opts.ErrOut,
 		now:           opts.Now,
 		host:          opts.Host,
+		diagnostics:   opts.Diagnostics,
 	}
 }
 
@@ -54,7 +55,7 @@ func (ds *DockerScanner) Scan(ctx context.Context, containers []string) ([]domai
 	for _, container := range containers {
 		reader, err := ds.dockerClient.Logs(container, false, cfg.Since)
 		if err != nil {
-			logScanError(ds.errOut, container, err)
+			ds.diagnostics.Error(fmt.Sprintf("Error fetching logs for container %s: %v", container, err), nil)
 			continue
 		}
 
@@ -85,7 +86,7 @@ func (ds *DockerScanner) Scan(ctx context.Context, containers []string) ([]domai
 					if err == io.EOF {
 						break
 					}
-					logScanError(ds.errOut, container, err)
+					ds.diagnostics.Error(fmt.Sprintf("Error reading logs for container %s: %v", container, err), nil)
 					return
 				}
 			}
@@ -105,7 +106,7 @@ func (ds *DockerScanner) Follow(ctx context.Context, containers []string, f form
 
 			reader, err := ds.dockerClient.Logs(container, true, "")
 			if err != nil {
-				logScanError(ds.errOut, container, err)
+				ds.diagnostics.Error(fmt.Sprintf("Error fetching logs for container %s: %v", container, err), nil)
 				return
 			}
 			defer reader.Close()
@@ -125,7 +126,7 @@ func (ds *DockerScanner) Follow(ctx context.Context, containers []string, f form
 					if err == io.EOF {
 						break
 					}
-					logScanError(ds.errOut, container, err)
+					ds.diagnostics.Error(fmt.Sprintf("Error reading logs for container %s: %v", container, err), nil)
 					return
 				}
 			}

--- a/internal/scanner/docker_scanner_test.go
+++ b/internal/scanner/docker_scanner_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/sagarmaheshwary/reqlog/internal/config"
+	"github.com/sagarmaheshwary/reqlog/internal/diagnostics"
 	"github.com/sagarmaheshwary/reqlog/internal/docker"
 	"github.com/sagarmaheshwary/reqlog/internal/domain"
 	"github.com/sagarmaheshwary/reqlog/internal/formatter"
@@ -29,9 +30,9 @@ func newTestDockerScanner(cfg *Config, client docker.DockerClient) *DockerScanne
 	return NewDockerScanner(&DockerScannerOpts{
 		LineProcessor: lp,
 		Out:           io.Discard,
-		ErrOut:        io.Discard,
 		Now:           time.Now(),
-		dockerClient:  client,
+		DockerClient:  client,
+		Diagnostics:   diagnostics.NewDiagnostics(),
 	})
 }
 
@@ -46,7 +47,6 @@ func TestDockerScanner_Scan(t *testing.T) {
 		cfg        *Config
 		containers []string
 		want       int
-		wantErrLog string
 	}{
 		{
 			name: "single container logs",
@@ -103,16 +103,6 @@ func TestDockerScanner_Scan(t *testing.T) {
 			containers: []string{"good", "bad"},
 			want:       1,
 		},
-		{
-			name: "logs error output",
-			logsFn: func(container string, follow bool, since string) (io.ReadCloser, error) {
-				return nil, fmt.Errorf("docker scan error")
-			},
-			cfg:        &Config{SearchValue: "123", Keys: []string{"user"}},
-			containers: []string{"auth"},
-			want:       0,
-			wantErrLog: "docker scan error",
-		},
 	}
 
 	for _, tt := range tests {
@@ -123,13 +113,13 @@ func TestDockerScanner_Scan(t *testing.T) {
 			}
 
 			lp := NewLineProcessor(tt.cfg, NewTimeParser())
-			var out, errOut bytes.Buffer
+			var out bytes.Buffer
 			ds := NewDockerScanner(&DockerScannerOpts{
 				LineProcessor: lp,
 				Out:           &out,
-				ErrOut:        &errOut,
 				Now:           time.Now(),
-				dockerClient:  mock,
+				DockerClient:  mock,
+				Diagnostics:   diagnostics.NewDiagnostics(),
 			})
 
 			results, err := ds.Scan(t.Context(), tt.containers)
@@ -140,10 +130,6 @@ func TestDockerScanner_Scan(t *testing.T) {
 			if len(results) != tt.want {
 				fmt.Println(results)
 				t.Errorf("expected %d results, got %d", tt.want, len(results))
-			}
-
-			if tt.wantErrLog != "" && !strings.Contains(errOut.String(), tt.wantErrLog) {
-				t.Errorf("expected error log containing %q, got %q", tt.wantErrLog, errOut.String())
 			}
 		})
 	}
@@ -268,13 +254,12 @@ func TestDockerScanner_Scan_Latest(t *testing.T) {
 
 	lp := NewLineProcessor(cfg, NewTimeParser())
 
-	var out, errOut bytes.Buffer
+	var out bytes.Buffer
 	ds := NewDockerScanner(&DockerScannerOpts{
 		LineProcessor: lp,
 		Out:           &out,
-		ErrOut:        &errOut,
 		Now:           time.Now(),
-		dockerClient:  mock,
+		DockerClient:  mock,
 	})
 
 	results, err := ds.Scan(t.Context(), []string{"a", "b"})
@@ -333,14 +318,14 @@ func TestDockerScanner_Scan_Context(t *testing.T) {
 
 	lp := NewLineProcessor(cfg, NewTimeParser())
 
-	var out, errOut bytes.Buffer
+	var out bytes.Buffer
 
 	ds := NewDockerScanner(&DockerScannerOpts{
 		LineProcessor: lp,
 		Out:           &out,
-		ErrOut:        &errOut,
 		Now:           time.Now(),
-		dockerClient:  mock,
+		DockerClient:  mock,
+		Diagnostics:   diagnostics.NewDiagnostics(),
 	})
 
 	results, err := ds.Scan(t.Context(), []string{"auth"})
@@ -542,9 +527,9 @@ func TestDockerScanner_Follow(t *testing.T) {
 			ds := NewDockerScanner(&DockerScannerOpts{
 				LineProcessor: lp,
 				Out:           &out,
-				ErrOut:        io.Discard,
 				Now:           time.Now(),
-				dockerClient:  client,
+				DockerClient:  client,
+				Diagnostics:   diagnostics.NewDiagnostics(),
 			})
 
 			ctx, cancel := context.WithTimeout(t.Context(), 500*time.Millisecond)
@@ -573,40 +558,93 @@ func TestDockerScanner_Follow(t *testing.T) {
 	}
 }
 
-func TestDockerScanner_Follow_Errors(t *testing.T) {
+func TestDockerScanner_Scan_LogsErrorCreatesDiagnostic(t *testing.T) {
 	cfg := &Config{
 		SearchValue: "123",
 		Keys:        []string{"user"},
 	}
+
 	lp := NewLineProcessor(cfg, NewTimeParser())
 
 	client := &mockDockerClient{
 		logsFn: func(container string, follow bool, since string) (io.ReadCloser, error) {
-			return nil, fmt.Errorf("docker error for %s", container)
+			return nil, errors.New("docker failed")
 		},
-		listFn: func() ([]string, error) { return []string{"auth"}, nil },
 	}
-
-	var out bytes.Buffer
-	var errOut bytes.Buffer
 
 	ds := NewDockerScanner(&DockerScannerOpts{
 		LineProcessor: lp,
-		Out:           &out,
-		ErrOut:        &errOut,
+		DockerClient:  client,
+		Out:           io.Discard,
 		Now:           time.Now(),
-		dockerClient:  client,
+		Diagnostics:   diagnostics.NewDiagnostics(),
 	})
 
-	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
-	defer cancel()
+	entries, err := ds.Scan(t.Context(), []string{"auth"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(entries) != 0 {
+		t.Fatalf("expected no log entries, got %d", len(entries))
+	}
+
+	diags := ds.diagnostics.Entries()
+
+	if len(diags) != 1 {
+		t.Fatalf("expected 1 diagnostic, got %d", len(diags))
+	}
+
+	if !diags[0].IsDiagnostics {
+		t.Fatal("expected diagnostic entry")
+	}
+
+	if diags[0].Fields["level"] != "error" {
+		t.Fatalf("expected error level, got %v", diags[0].Fields["level"])
+	}
+
+	want := "Error fetching logs for container auth: docker failed"
+
+	if diags[0].Message != want {
+		t.Fatalf("expected %q got %q", want, diags[0].Message)
+	}
+}
+
+func TestDockerScanner_Follow_LogsErrorCreatesDiagnostic(t *testing.T) {
+	cfg := &Config{
+		SearchValue: "123",
+		Keys:        []string{"user"},
+	}
+
+	lp := NewLineProcessor(cfg, NewTimeParser())
+
+	client := &mockDockerClient{
+		logsFn: func(container string, follow bool, since string) (io.ReadCloser, error) {
+			return nil, errors.New("docker failed")
+		},
+	}
+
+	ds := NewDockerScanner(&DockerScannerOpts{
+		LineProcessor: lp,
+		DockerClient:  client,
+		Out:           io.Discard,
+		Now:           time.Now(),
+		Diagnostics:   diagnostics.NewDiagnostics(),
+	})
 
 	f := formatter.NewFormatter(&formatter.Opts{
 		Output: config.OutputPretty,
 	})
-	ds.Follow(ctx, []string{"auth"}, f)
 
-	if !strings.Contains(errOut.String(), "docker error for auth") {
-		t.Errorf("expected error log, got %q", errOut.String())
+	ds.Follow(t.Context(), []string{"auth"}, f)
+
+	diags := ds.diagnostics.Entries()
+
+	if len(diags) != 1 {
+		t.Fatalf("expected 1 diagnostic, got %d", len(diags))
+	}
+
+	if diags[0].Fields["level"] != "error" {
+		t.Fatalf("expected error level, got %v", diags[0].Fields["level"])
 	}
 }

--- a/internal/scanner/factory.go
+++ b/internal/scanner/factory.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/sagarmaheshwary/reqlog/internal/config"
+	"github.com/sagarmaheshwary/reqlog/internal/diagnostics"
 	"github.com/sagarmaheshwary/reqlog/internal/docker"
 	"github.com/sagarmaheshwary/reqlog/internal/transport"
 )
@@ -16,6 +17,7 @@ type FactoryOpts struct {
 	Executor      transport.Executor
 	LogFileReader transport.LogFileReader
 	Host          string
+	Diagnostics   *diagnostics.Diagnostics
 }
 
 func New(opts *FactoryOpts) (Scanner, error) {
@@ -25,19 +27,19 @@ func New(opts *FactoryOpts) (Scanner, error) {
 			LineProcessor:  opts.LineProcessor,
 			FollowInterval: time.Second,
 			Out:            os.Stdout,
-			ErrOut:         os.Stderr,
 			Now:            time.Now(),
 			LogFileReader:  opts.LogFileReader,
 			Host:           opts.Host,
+			Diagnostics:    opts.Diagnostics,
 		}), nil
 	case config.SourceDocker:
 		return NewDockerScanner(&DockerScannerOpts{
 			LineProcessor: opts.LineProcessor,
-			dockerClient:  docker.NewDockerCLIClient(opts.Executor),
+			DockerClient:  docker.NewDockerCLIClient(opts.Executor),
 			Out:           os.Stdout,
-			ErrOut:        os.Stderr,
 			Now:           time.Now(),
 			Host:          opts.Host,
+			Diagnostics:   opts.Diagnostics,
 		}), nil
 	default:
 		return nil, fmt.Errorf("unknown source type")

--- a/internal/scanner/file_scanner.go
+++ b/internal/scanner/file_scanner.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/sagarmaheshwary/reqlog/internal/diagnostics"
 	"github.com/sagarmaheshwary/reqlog/internal/domain"
 	"github.com/sagarmaheshwary/reqlog/internal/formatter"
 	"github.com/sagarmaheshwary/reqlog/internal/transport"
@@ -19,20 +20,20 @@ type FileScanner struct {
 	lineProcessor  *LineProcessor
 	followInterval time.Duration
 	out            io.Writer
-	errOut         io.Writer
 	now            time.Time
 	logFileReader  transport.LogFileReader
 	host           string
+	diagnostics    *diagnostics.Diagnostics
 }
 
 type FileScannerOpts struct {
 	LineProcessor  *LineProcessor
 	FollowInterval time.Duration
 	Out            io.Writer
-	ErrOut         io.Writer
 	Now            time.Time
 	LogFileReader  transport.LogFileReader
 	Host           string
+	Diagnostics    *diagnostics.Diagnostics
 }
 
 func NewFileScanner(opts *FileScannerOpts) *FileScanner {
@@ -41,10 +42,10 @@ func NewFileScanner(opts *FileScannerOpts) *FileScanner {
 		lineProcessor:  opts.LineProcessor,
 		followInterval: opts.FollowInterval,
 		out:            opts.Out,
-		errOut:         opts.ErrOut,
 		now:            opts.Now,
 		logFileReader:  opts.LogFileReader,
 		host:           opts.Host,
+		diagnostics:    opts.Diagnostics,
 	}
 }
 
@@ -59,7 +60,7 @@ func (fs *FileScanner) Scan(ctx context.Context, files []string) ([]domain.LogEn
 	for _, path := range files {
 		file, err := fs.logFileReader.Open(ctx, path)
 		if err != nil {
-			logScanError(fs.errOut, path, err)
+			fs.diagnostics.Error(fmt.Sprintf("Error opening file %s: %v", path, err), nil)
 			continue
 		}
 
@@ -104,7 +105,7 @@ func (fs *FileScanner) Scan(ctx context.Context, files []string) ([]domain.LogEn
 		}()
 
 		if err != nil {
-			logScanError(fs.errOut, path, err)
+			fs.diagnostics.Error(fmt.Sprintf("Error reading file %s: %v", path, err), nil)
 		}
 
 		fs.offsets[path] = offset
@@ -139,7 +140,7 @@ func (fs *FileScanner) scanFromOffset(ctx context.Context, path string, f format
 		path,
 	)
 	if err != nil {
-		logScanError(fs.errOut, path, err)
+		fs.diagnostics.Error(fmt.Sprintf("Error reading file %s: %v", path, err), nil)
 		return
 	}
 
@@ -155,7 +156,7 @@ func (fs *FileScanner) scanFromOffset(ctx context.Context, path string, f format
 
 	file, err := fs.logFileReader.OpenFromOffset(ctx, path, offset)
 	if err != nil {
-		logScanError(fs.errOut, path, err)
+		fs.diagnostics.Error(fmt.Sprintf("Error opening file %s: %v", path, err), nil)
 		return
 	}
 	defer file.Close()
@@ -178,7 +179,7 @@ func (fs *FileScanner) scanFromOffset(ctx context.Context, path string, f format
 			if err == io.EOF {
 				break
 			}
-			logScanError(fs.errOut, path, err)
+			fs.diagnostics.Error(fmt.Sprintf("Error reading file %s: %v", path, err), nil)
 			return
 		}
 	}
@@ -193,7 +194,7 @@ func (fs *FileScanner) ListSources(ctx context.Context) ([]string, error) {
 		Recursive: cfg.Recursive,
 		Services:  cfg.Services,
 		OnError: func(path string, err error) {
-			logScanError(fs.errOut, path, err)
+			fs.diagnostics.Error(fmt.Sprintf("Error listing file %s: %v", path, err), nil)
 		},
 	})
 	if err != nil {

--- a/internal/scanner/file_scanner_benchmark_test.go
+++ b/internal/scanner/file_scanner_benchmark_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/sagarmaheshwary/reqlog/internal/config"
+	"github.com/sagarmaheshwary/reqlog/internal/diagnostics"
 	"github.com/sagarmaheshwary/reqlog/internal/transport"
 )
 
@@ -91,9 +92,9 @@ func BenchmarkScanDir_PlainText(b *testing.B) {
 			LineProcessor:  lp,
 			FollowInterval: time.Second,
 			Out:            os.Stdout,
-			ErrOut:         os.Stderr,
 			Now:            time.Now(),
 			LogFileReader:  transport.NewLogFileReader(nil),
+			Diagnostics:    diagnostics.NewDiagnostics(),
 		})
 		files, err := fs.ListSources(b.Context())
 		if err != nil {
@@ -131,9 +132,9 @@ func BenchmarkScanDir_JSON(b *testing.B) {
 			LineProcessor:  lp,
 			FollowInterval: time.Second,
 			Out:            os.Stdout,
-			ErrOut:         os.Stderr,
 			Now:            time.Now(),
 			LogFileReader:  transport.NewLogFileReader(nil),
+			Diagnostics:    diagnostics.NewDiagnostics(),
 		})
 		files, err := fs.ListSources(b.Context())
 		if err != nil {

--- a/internal/scanner/file_scanner_test.go
+++ b/internal/scanner/file_scanner_test.go
@@ -3,6 +3,7 @@ package scanner
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -14,7 +15,9 @@ import (
 	"time"
 
 	"github.com/sagarmaheshwary/reqlog/internal/config"
+	"github.com/sagarmaheshwary/reqlog/internal/diagnostics"
 	"github.com/sagarmaheshwary/reqlog/internal/domain"
+	"github.com/sagarmaheshwary/reqlog/internal/formatter"
 	"github.com/sagarmaheshwary/reqlog/internal/transport"
 )
 
@@ -24,9 +27,9 @@ func newTestFileScanner(cfg *Config) *FileScanner {
 		LineProcessor:  lp,
 		FollowInterval: time.Second,
 		Out:            io.Discard,
-		ErrOut:         io.Discard,
 		Now:            time.Now(),
 		LogFileReader:  transport.NewLogFileReader(nil),
+		Diagnostics:    diagnostics.NewDiagnostics(),
 	})
 }
 
@@ -57,9 +60,9 @@ func TestFileScanner_Scan(t *testing.T) {
 		LineProcessor:  lp,
 		FollowInterval: time.Second,
 		Out:            io.Discard,
-		ErrOut:         io.Discard,
 		Now:            time.Now(),
 		LogFileReader:  transport.NewLogFileReader(nil),
+		Diagnostics:    diagnostics.NewDiagnostics(),
 	})
 
 	files, err := fs.ListSources(t.Context())
@@ -106,9 +109,9 @@ func TestFileScanner_Scan_WithSince(t *testing.T) {
 		LineProcessor:  lp,
 		FollowInterval: time.Second,
 		Out:            io.Discard,
-		ErrOut:         io.Discard,
 		Now:            time.Now(),
 		LogFileReader:  transport.NewLogFileReader(nil),
+		Diagnostics:    diagnostics.NewDiagnostics(),
 	})
 	files, err := fs.ListSources(t.Context())
 	if err != nil {
@@ -142,9 +145,9 @@ func TestFileScanner_Scan_IgnoreCase(t *testing.T) {
 		LineProcessor:  lp,
 		FollowInterval: time.Second,
 		Out:            io.Discard,
-		ErrOut:         io.Discard,
 		Now:            time.Now(),
 		LogFileReader:  transport.NewLogFileReader(nil),
+		Diagnostics:    diagnostics.NewDiagnostics(),
 	})
 	files, err := fs.ListSources(t.Context())
 	if err != nil {
@@ -177,9 +180,9 @@ func TestFileScanner_Scan_IgnoresNonLogFiles(t *testing.T) {
 		LineProcessor:  lp,
 		FollowInterval: time.Second,
 		Out:            io.Discard,
-		ErrOut:         io.Discard,
 		Now:            time.Now(),
 		LogFileReader:  transport.NewLogFileReader(nil),
+		Diagnostics:    diagnostics.NewDiagnostics(),
 	})
 	files, err := fs.ListSources(t.Context())
 	if err != nil {
@@ -334,40 +337,6 @@ func TestScan_NoTrailingNewline(t *testing.T) {
 	}
 }
 
-func TestFileScanner_Scan_ErrorLogging(t *testing.T) {
-	cfg := &Config{
-		SearchValue: "123",
-		Keys:        []string{"user"},
-	}
-	lp := NewLineProcessor(cfg, NewTimeParser())
-
-	// pass a missing file to trigger error
-	files := []string{"/tmp/nonexistent.log"}
-
-	var out bytes.Buffer
-	var errOut bytes.Buffer
-	fs := NewFileScanner(&FileScannerOpts{
-		LineProcessor:  lp,
-		FollowInterval: time.Second,
-		Out:            &out,
-		ErrOut:         &errOut,
-		Now:            time.Now(),
-		LogFileReader:  transport.NewLogFileReader(nil),
-	})
-	results, err := fs.Scan(t.Context(), files)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if len(results) != 0 {
-		t.Errorf("expected 0 results, got %d", len(results))
-	}
-
-	if !strings.Contains(errOut.String(), "/tmp/nonexistent.log") {
-		t.Errorf("expected error log, got %q", errOut.String())
-	}
-}
-
 func TestFileScanner_Scan_InvalidSince(t *testing.T) {
 	dir := t.TempDir()
 
@@ -434,9 +403,9 @@ func TestFileScanner_Scan_JSON(t *testing.T) {
 				LineProcessor:  lp,
 				FollowInterval: time.Second,
 				Out:            io.Discard,
-				ErrOut:         io.Discard,
 				Now:            time.Now(),
 				LogFileReader:  transport.NewLogFileReader(nil),
+				Diagnostics:    diagnostics.NewDiagnostics(),
 			})
 			files, err := fs.ListSources(t.Context())
 			if err != nil {
@@ -634,6 +603,49 @@ func TestListSources(t *testing.T) {
 	}
 }
 
+func TestListSources_OnErrorCallback(t *testing.T) {
+	fs := newTestFileScanner(&Config{})
+
+	fs.logFileReader = &mockLogFileReader{
+		listFilesFn: func(
+			ctx context.Context,
+			dir string,
+			opts transport.ListOptions,
+		) ([]string, error) {
+			if opts.OnError != nil {
+				opts.OnError("/tmp/bad.log", errors.New("permission denied"))
+			}
+
+			return []string{"auth.log"}, nil
+		},
+	}
+
+	files, err := fs.ListSources(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(files, []string{"auth.log"}) {
+		t.Fatalf("expected files returned, got %v", files)
+	}
+
+	entries := fs.diagnostics.Entries()
+
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 diagnostic entry, got %d", len(entries))
+	}
+
+	entry := entries[0]
+
+	if entry.Fields["level"] != "error" {
+		t.Fatalf("expected error level, got %v", entry.Fields["level"])
+	}
+
+	if !strings.Contains(entry.Message, "Error listing file /tmp/bad.log") {
+		t.Fatalf("unexpected message: %q", entry.Message)
+	}
+}
+
 func TestFileScanner_Follow(t *testing.T) {
 	dir := t.TempDir()
 
@@ -697,9 +709,9 @@ func TestFileScanner_Follow(t *testing.T) {
 				LineProcessor:  lp,
 				FollowInterval: 10 * time.Millisecond,
 				Out:            &out,
-				ErrOut:         io.Discard,
 				Now:            time.Now(),
 				LogFileReader:  transport.NewLogFileReader(nil),
+				Diagnostics:    diagnostics.NewDiagnostics(),
 			})
 
 			ctx, cancel := context.WithTimeout(t.Context(), 500*time.Millisecond)
@@ -733,34 +745,88 @@ func TestFileScanner_Follow(t *testing.T) {
 	}
 }
 
-func TestFileScanner_Follow_Errors(t *testing.T) {
+func TestFileScanner_Scan_OpenErrorCreatesDiagnostic(t *testing.T) {
 	cfg := &Config{
 		SearchValue: "123",
 		Keys:        []string{"user"},
 	}
+
 	lp := NewLineProcessor(cfg, NewTimeParser())
 
-	var out bytes.Buffer
-	var errOut bytes.Buffer
 	fs := NewFileScanner(&FileScannerOpts{
-		LineProcessor:  lp,
-		FollowInterval: 10 * time.Millisecond,
-		Out:            &out,
-		ErrOut:         &errOut,
-		Now:            time.Now(),
-		LogFileReader:  transport.NewLogFileReader(nil),
+		LineProcessor: lp,
+		Out:           io.Discard,
+		Now:           time.Now(),
+		Diagnostics:   diagnostics.NewDiagnostics(),
 	})
 
-	// pass a missing file to trigger error
-	files := []string{"/tmp/nonexistent.log"}
+	fs.logFileReader = &mockLogFileReader{
+		openFn: func(ctx context.Context, path string) (io.ReadCloser, error) {
+			return nil, errors.New("open failed")
+		},
+	}
 
-	ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
-	defer cancel()
+	entries, err := fs.Scan(t.Context(), []string{"app.log"})
+	if err != nil {
+		t.Fatal(err)
+	}
 
-	fs.Follow(ctx, files, &testFormatter{})
+	if len(entries) != 0 {
+		t.Fatalf("expected no entries, got %d", len(entries))
+	}
 
-	if !strings.Contains(errOut.String(), "error scanning /tmp/nonexistent.log") {
-		t.Errorf("expected error log, got %q", errOut.String())
+	diags := fs.diagnostics.Entries()
+
+	if len(diags) != 1 {
+		t.Fatalf("expected 1 diagnostic, got %d", len(diags))
+	}
+
+	want := "Error opening file app.log: open failed"
+
+	if diags[0].Message != want {
+		t.Fatalf("expected %q got %q", want, diags[0].Message)
+	}
+}
+
+func TestFileScanner_ScanFromOffset_SizeErrorCreatesDiagnostic(t *testing.T) {
+	cfg := &Config{
+		SearchValue: "123",
+		Keys:        []string{"user"},
+	}
+
+	lp := NewLineProcessor(cfg, NewTimeParser())
+
+	fs := NewFileScanner(&FileScannerOpts{
+		LineProcessor: lp,
+		Out:           io.Discard,
+		Now:           time.Now(),
+		Diagnostics:   diagnostics.NewDiagnostics(),
+	})
+
+	fs.offsets["app.log"] = 0
+
+	fs.logFileReader = &mockLogFileReader{
+		sizeFn: func(ctx context.Context, path string) (int64, error) {
+			return 0, errors.New("size failed")
+		},
+	}
+
+	f := formatter.NewFormatter(&formatter.Opts{
+		Output: config.OutputPretty,
+	})
+
+	fs.scanFromOffset(t.Context(), "app.log", f)
+
+	diags := fs.diagnostics.Entries()
+
+	if len(diags) != 1 {
+		t.Fatalf("expected 1 diagnostic, got %d", len(diags))
+	}
+
+	want := "Error reading file app.log: size failed"
+
+	if diags[0].Message != want {
+		t.Fatalf("expected %q got %q", want, diags[0].Message)
 	}
 }
 

--- a/internal/scanner/mocks_test.go
+++ b/internal/scanner/mocks_test.go
@@ -1,6 +1,7 @@
 package scanner
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"sort"
@@ -8,6 +9,7 @@ import (
 	"time"
 
 	"github.com/sagarmaheshwary/reqlog/internal/domain"
+	"github.com/sagarmaheshwary/reqlog/internal/transport"
 )
 
 type mockDockerClient struct {
@@ -47,4 +49,31 @@ func (f *testFormatter) Format(entry domain.LogEntry) string {
 		entry.Message,
 		strings.Join(fields, " "),
 	)
+}
+
+type mockLogFileReader struct {
+	openFn           func(context.Context, string) (io.ReadCloser, error)
+	openFromOffsetFn func(context.Context, string, int64) (io.ReadCloser, error)
+	sizeFn           func(context.Context, string) (int64, error)
+	listFilesFn      func(context.Context, string, transport.ListOptions) ([]string, error)
+}
+
+func (m *mockLogFileReader) Open(ctx context.Context, path string) (io.ReadCloser, error) {
+	return m.openFn(ctx, path)
+}
+
+func (m *mockLogFileReader) OpenFromOffset(ctx context.Context, path string, offset int64) (io.ReadCloser, error) {
+	return m.openFromOffsetFn(ctx, path, offset)
+}
+
+func (m *mockLogFileReader) Size(ctx context.Context, path string) (int64, error) {
+	return m.sizeFn(ctx, path)
+}
+
+func (m *mockLogFileReader) ListFiles(
+	ctx context.Context,
+	dir string,
+	opts transport.ListOptions,
+) ([]string, error) {
+	return m.listFilesFn(ctx, dir, opts)
 }

--- a/internal/scanner/utils.go
+++ b/internal/scanner/utils.go
@@ -3,7 +3,6 @@ package scanner
 import (
 	"container/heap"
 	"fmt"
-	"io"
 	"strings"
 	"time"
 
@@ -83,10 +82,6 @@ func containsFoldASCII(s, substr string) bool {
 	}
 
 	return false
-}
-
-func logScanError(out io.Writer, path string, err error) {
-	fmt.Fprintf(out, "error scanning %s: %v\n", path, err)
 }
 
 func drainHeap(h *entryHeap) []domain.LogEntry {


### PR DESCRIPTION
## Summary

Add support for verbose diagnostics output to surface warnings and errors encountered during log scanning without interfering with normal search results.

## Changes

* Added diagnostics package for collecting warnings and errors
* Added `--verbose` (`-V`) flag to display diagnostics
* Updated file and Docker scanners to record scan failures as diagnostics
* Render diagnostics separately from matched log entries
* Excluded diagnostics from `--fields` filtering logic
* Added test coverage for diagnostic generation

## Why

Previously, scan errors were either printed directly or lost. Diagnostics provide a consistent way to surface operational issues while keeping log search results, sorting, context, and limit behavior unchanged.

## Impact

* No breaking changes
* Diagnostics are only shown when `--verbose` is enabled
