### PR TITLE
perf(ssh): connect to hosts concurrently and continue on connection failures

### DIFF
--- a/internal/app/run.go
+++ b/internal/app/run.go
@@ -2,9 +2,11 @@ package app
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sort"
 	"strings"
+	"sync"
 
 	"github.com/sagarmaheshwary/reqlog/internal/config"
 	"github.com/sagarmaheshwary/reqlog/internal/diagnostics"
@@ -121,7 +123,11 @@ func resolveSource(
 	return sources, nil
 }
 
-func scannersForConfig(cfg *config.Config, lp *scanner.LineProcessor, dg *diagnostics.Diagnostics) ([]scannerSource, error) {
+func scannersForConfig(
+	cfg *config.Config,
+	lp *scanner.LineProcessor,
+	dg *diagnostics.Diagnostics,
+) ([]scannerSource, error) {
 	if cfg.Host == "" {
 		scn, err := scanner.New(&scanner.FactoryOpts{
 			Source:        cfg.Source,
@@ -140,35 +146,61 @@ func scannersForConfig(cfg *config.Config, lp *scanner.LineProcessor, dg *diagno
 	hosts := strings.Split(cfg.Host, ",")
 	scanners := make([]scannerSource, 0, len(hosts))
 
+	var (
+		wg sync.WaitGroup
+		mu sync.Mutex
+	)
+
 	for _, host := range hosts {
 		h, ok := cfg.Config.Hosts[host]
 		if !ok {
-			return nil, fmt.Errorf("invalid value passed to --host: %s", host)
+			keys := make([]string, 0, len(cfg.Config.Hosts))
+			for k := range cfg.Config.Hosts {
+				keys = append(keys, k)
+			}
+
+			return nil, fmt.Errorf("invalid value passed to --host: %s, available hosts are %v", host, keys)
 		}
 
-		sshClient, err := transport.NewSSHClient(h, ssh.Dial)
-		if err != nil {
-			return nil, err
-		}
+		wg.Add(1)
 
-		executor := transport.NewExecutor(sshClient)
-		scn, err := scanner.New(&scanner.FactoryOpts{
-			Source:        cfg.Source,
-			LineProcessor: lp,
-			Executor:      executor,
-			LogFileReader: transport.NewLogFileReader(executor),
-			Host:          host,
-			Diagnostics:   dg,
-		})
-		if err != nil {
-			return nil, err
-		}
+		go func(host string, h config.Host) {
+			defer wg.Done()
 
-		scanners = append(scanners, scannerSource{
-			scanner:   scn,
-			sshClient: sshClient,
-			sources:   make([]string, 0),
-		})
+			sshClient, err := transport.NewSSHClient(h, ssh.Dial)
+			if err != nil {
+				dg.Error(fmt.Sprintf("Error creating SSH client for host %s: %v", host, err), nil)
+				return
+			}
+
+			executor := transport.NewExecutor(sshClient)
+			scn, err := scanner.New(&scanner.FactoryOpts{
+				Source:        cfg.Source,
+				LineProcessor: lp,
+				Executor:      executor,
+				LogFileReader: transport.NewLogFileReader(executor),
+				Host:          host,
+				Diagnostics:   dg,
+			})
+			if err != nil {
+				sshClient.Close()
+				dg.Error(fmt.Sprintf("Error creating scanner for host %s: %v", host, err), nil)
+				return
+			}
+			mu.Lock()
+			scanners = append(scanners, scannerSource{
+				scanner:   scn,
+				sshClient: sshClient,
+				sources:   make([]string, 0),
+			})
+			mu.Unlock()
+		}(host, h)
+	}
+
+	wg.Wait()
+
+	if len(scanners) == 0 {
+		return nil, errors.New("failed to connect to any configured host")
 	}
 
 	return scanners, nil

--- a/internal/formatter/formatter.go
+++ b/internal/formatter/formatter.go
@@ -34,8 +34,9 @@ type Opts struct {
 func NewFormatter(opts *Opts) *Formatter {
 	max := 0
 	for _, e := range opts.Entries {
-		if len(e.Service) > max {
-			max = len(e.Service)
+		label := displayName(e)
+		if len(label) > max {
+			max = len(label)
 		}
 	}
 
@@ -49,11 +50,11 @@ func NewFormatter(opts *Opts) *Formatter {
 	}
 }
 
-func (f *Formatter) padAfter(service string) string {
-	if len(service) >= f.serviceWidth {
+func (f *Formatter) padAfter(label string) string {
+	if len(label) >= f.serviceWidth {
 		return ""
 	}
-	return strings.Repeat(" ", f.serviceWidth-len(service))
+	return strings.Repeat(" ", f.serviceWidth-len(label))
 }
 
 func (f *Formatter) Format(entry domain.LogEntry) string {
@@ -145,15 +146,10 @@ func (f *Formatter) outputJSONFields(
 
 func (f *Formatter) outputPretty(entry domain.LogEntry) string {
 	serviceColor := f.colorizer.Color(entry.Service)
-	padding := f.padAfter(entry.Service)
+	label := displayName(entry)
+	padding := f.padAfter(label)
 
 	msg := f.renderPrettyMessage(entry)
-
-	service := entry.Service
-
-	if entry.Host != "" {
-		service = entry.Host + ":" + entry.Service
-	}
 
 	return fmt.Sprintf(
 		"%s%s%s%s %s[%s]%s%s | %s%s%s",
@@ -163,7 +159,7 @@ func (f *Formatter) outputPretty(entry domain.LogEntry) string {
 		reset,
 
 		serviceColor,
-		service,
+		label,
 		reset,
 		padding,
 
@@ -326,4 +322,11 @@ func marshal(out any, entry domain.LogEntry) string {
 
 	fallback, _ := json.Marshal(errorOut)
 	return string(fallback)
+}
+
+func displayName(entry domain.LogEntry) string {
+	if entry.Host != "" {
+		return entry.Host + ":" + entry.Service
+	}
+	return entry.Service
 }

--- a/internal/formatter/formatter_test.go
+++ b/internal/formatter/formatter_test.go
@@ -674,6 +674,40 @@ func TestFormatter_RenderPrettyFields(t *testing.T) {
 	}
 }
 
+func TestDisplayName(t *testing.T) {
+	tests := []struct {
+		name  string
+		entry domain.LogEntry
+		want  string
+	}{
+		{
+			name: "service only",
+			entry: domain.LogEntry{
+				Service: "api",
+			},
+			want: "api",
+		},
+		{
+			name: "host and service",
+			entry: domain.LogEntry{
+				Host:    "prod-1",
+				Service: "api",
+			},
+			want: "prod-1:api",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := displayName(tt.entry)
+
+			if got != tt.want {
+				t.Fatalf("expected %q, got %q", tt.want, got)
+			}
+		})
+	}
+}
+
 func assertContains(t *testing.T, got, want string) {
 	t.Helper()
 


### PR DESCRIPTION
## Summary

This PR improves the SSH backend by reducing startup latency when searching multiple remote hosts and making distributed searches resilient to individual host failures.

Instead of connecting to SSH hosts sequentially and aborting on the first connection error, reqlog now establishes connections concurrently and continues searching any hosts that are reachable.

## Changes

### Concurrent SSH connections

* Establish SSH connections to multiple hosts concurrently
* Significantly reduce startup time when searching multiple remote hosts
* Improve responsiveness for distributed log searches

### Fault-tolerant host handling

* Continue searching when individual hosts are unreachable
* Record connection failures as diagnostics instead of aborting the search

### Formatter

* Fix pretty output alignment by accounting for host names when calculating service column padding

## Why

Reqlog is designed for searching logs across distributed systems. Requiring every configured host to be reachable before returning any results makes the tool less useful during outages—the very situations where log searches are often needed most.

By connecting to hosts concurrently and treating per-host failures as diagnostics, reqlog now:

* returns partial results whenever possible
* provides better visibility into connection failures
* improves search performance across multiple remote hosts

## Impact

* Faster startup for SSH searches involving multiple hosts
* Improved resilience when some hosts are unavailable
* Backward-compatible behavior for successful searches
* Better diagnostics via `--verbose`
