### PR TITLE
build: improve release pipeline for package manager distribution

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -105,5 +105,5 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           generate_release_notes: true
-          files: |
-            dist/*
+          prerelease: ${{ contains(github.ref_name, '-rc') || contains(github.ref_name, '-beta') }}
+          files: dist/*

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -43,20 +43,67 @@ jobs:
         run: ./reqlog-linux-amd64 --version
 
       - name: Archive binaries
+        env:
+          VERSION: ${{ steps.version.outputs.VERSION }}
         run: |
-          zip  reqlog-windows-amd64.zip       reqlog-windows-amd64.exe
-          tar -czf reqlog-linux-amd64.tar.gz  reqlog-linux-amd64
-          tar -czf reqlog-linux-arm64.tar.gz  reqlog-linux-arm64
-          tar -czf reqlog-darwin-amd64.tar.gz reqlog-darwin-amd64
-          tar -czf reqlog-darwin-arm64.tar.gz reqlog-darwin-arm64
+          mkdir -p dist
+
+          package_tar() {
+            local binary="$1"
+            local archive="$2"
+
+            rm -rf pkg
+            mkdir pkg
+
+            cp "$binary" pkg/reqlog
+            cp LICENSE README.md pkg/
+
+            tar -czf "$archive" -C pkg .
+
+            rm -rf pkg
+          }
+
+          package_zip() {
+            local binary="$1"
+            local archive="$2"
+
+            rm -rf pkg
+            mkdir pkg
+
+            cp "$binary" pkg/reqlog.exe
+            cp LICENSE README.md pkg/
+
+            (
+              cd pkg
+              zip -q "../$archive" *
+            )
+
+            rm -rf pkg
+          }
+
+          package_tar reqlog-linux-amd64 \
+            dist/reqlog_${VERSION}_linux_amd64.tar.gz
+
+          package_tar reqlog-linux-arm64 \
+            dist/reqlog_${VERSION}_linux_arm64.tar.gz
+
+          package_tar reqlog-darwin-amd64 \
+            dist/reqlog_${VERSION}_darwin_amd64.tar.gz
+
+          package_tar reqlog-darwin-arm64 \
+            dist/reqlog_${VERSION}_darwin_arm64.tar.gz
+
+          package_zip reqlog-windows-amd64.exe \
+            dist/reqlog_${VERSION}_windows_amd64.zip
+
+      - name: Generate checksums
+        run: |
+          cd dist
+          sha256sum * > checksums.txt
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
           generate_release_notes: true
           files: |
-            reqlog-windows-amd64.zip
-            reqlog-linux-amd64.tar.gz
-            reqlog-linux-arm64.tar.gz
-            reqlog-darwin-amd64.tar.gz
-            reqlog-darwin-arm64.tar.gz
+            dist/*


### PR DESCRIPTION
### Summary

Prepare release artifacts for package manager distribution and release candidate testing.

### Changes

* Package binaries into versioned archives suitable for package managers.
* Include `README.md` and `LICENSE` in release archives.
* Generate `checksums.txt` for artifact verification and package manager integration.
* Move release artifacts into a dedicated `dist/` directory.
* Upload all generated artifacts as GitHub release assets.
* Add automatic GitHub prerelease detection for release candidate and beta tags.

### Motivation

These changes prepare `reqlog` for distribution through package managers such as:

* Homebrew
* Scoop
* APT (`.deb`)
* RPM (`.rpm`)

and establish support for testing release candidates using tags such as `v0.9.0-rc1` before publishing stable releases.
