### PR TITLE
build: migrate release pipeline to GoReleaser and automate package distribution

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,100 +10,21 @@ permissions:
 
 jobs:
   release:
-    name: Build and Release
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
-      - name: Set up Go
-        uses: actions/setup-go@v5
+      - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
 
-      - name: Extract version from tag
-        id: version
-        run: echo "VERSION=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
-
-      - name: Build binaries
-        env:
-          VERSION: ${{ steps.version.outputs.VERSION }}
-        run: |
-          # Linux
-          GOOS=linux  GOARCH=amd64 go build -ldflags="-X main.version=${VERSION}" -o reqlog-linux-amd64  ./cmd/reqlog
-          GOOS=linux  GOARCH=arm64 go build -ldflags="-X main.version=${VERSION}" -o reqlog-linux-arm64  ./cmd/reqlog
-          # Windows
-          GOOS=windows GOARCH=amd64 go build -ldflags="-X main.version=${VERSION}" -o reqlog-windows-amd64.exe ./cmd/reqlog
-          # macOS
-          GOOS=darwin GOARCH=amd64 go build -ldflags="-X main.version=${VERSION}" -o reqlog-darwin-amd64 ./cmd/reqlog
-          GOOS=darwin GOARCH=arm64 go build -ldflags="-X main.version=${VERSION}" -o reqlog-darwin-arm64 ./cmd/reqlog
-
-      - name: Verify version
-        run: ./reqlog-linux-amd64 --version
-
-      - name: Archive binaries
-        env:
-          VERSION: ${{ steps.version.outputs.VERSION }}
-        run: |
-          mkdir -p dist
-
-          package_tar() {
-            local binary="$1"
-            local archive="$2"
-
-            rm -rf pkg
-            mkdir pkg
-
-            cp "$binary" pkg/reqlog
-            cp LICENSE README.md pkg/
-
-            tar -czf "$archive" -C pkg .
-
-            rm -rf pkg
-          }
-
-          package_zip() {
-            local binary="$1"
-            local archive="$2"
-
-            rm -rf pkg
-            mkdir pkg
-
-            cp "$binary" pkg/reqlog.exe
-            cp LICENSE README.md pkg/
-
-            (
-              cd pkg
-              zip -q "../$archive" *
-            )
-
-            rm -rf pkg
-          }
-
-          package_tar reqlog-linux-amd64 \
-            dist/reqlog_${VERSION}_linux_amd64.tar.gz
-
-          package_tar reqlog-linux-arm64 \
-            dist/reqlog_${VERSION}_linux_arm64.tar.gz
-
-          package_tar reqlog-darwin-amd64 \
-            dist/reqlog_${VERSION}_darwin_amd64.tar.gz
-
-          package_tar reqlog-darwin-arm64 \
-            dist/reqlog_${VERSION}_darwin_arm64.tar.gz
-
-          package_zip reqlog-windows-amd64.exe \
-            dist/reqlog_${VERSION}_windows_amd64.zip
-
-      - name: Generate checksums
-        run: |
-          cd dist
-          sha256sum * > checksums.txt
-
-      - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+      - uses: goreleaser/goreleaser-action@v6
         with:
-          generate_release_notes: true
-          prerelease: ${{ contains(github.ref_name, '-rc') || contains(github.ref_name, '-beta') }}
-          files: dist/*
+          version: latest
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAP_GITHUB_TOKEN: ${{ secrets.TAP_GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -89,6 +89,10 @@ brews:
 
     directory: Formula
 
+    commit_author:
+      name: github-actions[bot]
+      email: 41898282+github-actions[bot]@users.noreply.github.com
+
     homepage: https://github.com/sagarmaheshwary/reqlog
 
     description: Search, trace, and stream logs across files, Docker containers, and remote hosts
@@ -108,6 +112,12 @@ scoops:
       owner: sagarmaheshwary
       name: scoop-bucket
       token: "{{ .Env.TAP_GITHUB_TOKEN }}"
+
+    directory: bucket
+
+    commit_author:
+      name: github-actions[bot]
+      email: 41898282+github-actions[bot]@users.noreply.github.com
 
     homepage: https://github.com/sagarmaheshwary/reqlog
 

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,116 @@
+version: 2
+
+project_name: reqlog
+
+before:
+  hooks:
+    - go mod tidy
+
+builds:
+  - id: reqlog
+    main: ./cmd/reqlog
+    binary: reqlog
+
+    env:
+      - CGO_ENABLED=0
+
+    goos:
+      - linux
+      - windows
+      - darwin
+
+    goarch:
+      - amd64
+      - arm64
+
+    ldflags:
+      - -s -w -X main.version={{ .Version }}
+
+archives:
+  - id: archives
+
+    name_template: >-
+      {{ .ProjectName }}_{{ .Version }}_
+      {{- .Os }}_
+      {{- .Arch }}
+
+    files:
+      - LICENSE
+      - README.md
+
+    formats:
+      - tar.gz
+
+    format_overrides:
+      - goos: windows
+        formats:
+          - zip
+
+checksum:
+  name_template: checksums.txt
+
+release:
+  prerelease: auto
+
+nfpms:
+  - id: packages
+
+    package_name: reqlog
+
+    homepage: https://github.com/sagarmaheshwary/reqlog
+
+    maintainer: Sagar Maheshwary <sagarmaheshwary31@gmail.com>
+
+    description: |
+      Search, trace, and stream logs across files, Docker containers, and remote hosts.
+
+    license: MIT
+
+    formats:
+      - deb
+      - rpm
+
+    bindir: /usr/bin
+
+    contents:
+      - src: LICENSE
+        dst: /usr/share/doc/reqlog/LICENSE
+
+      - src: README.md
+        dst: /usr/share/doc/reqlog/README.md
+
+brews:
+  - name: reqlog
+
+    repository:
+      owner: sagarmaheshwary
+      name: homebrew-tap
+      token: "{{ .Env.TAP_GITHUB_TOKEN }}"
+
+    directory: Formula
+
+    homepage: https://github.com/sagarmaheshwary/reqlog
+
+    description: Search, trace, and stream logs across files, Docker containers, and remote hosts
+
+    license: MIT
+
+    install: |
+      bin.install "reqlog"
+
+    test: |
+      system "#{bin}/reqlog", "--version"
+
+scoops:
+  - name: reqlog
+
+    repository:
+      owner: sagarmaheshwary
+      name: scoop-bucket
+      token: "{{ .Env.TAP_GITHUB_TOKEN }}"
+
+    homepage: https://github.com/sagarmaheshwary/reqlog
+
+    description: Search, trace, and stream logs across files, Docker containers, and remote hosts
+
+    license: MIT


### PR DESCRIPTION
### Summary

Replace the custom release workflow with GoReleaser to simplify release management and automate package distribution across supported platforms and package managers.

### Changes

* Migrate release pipeline from custom build scripts to GoReleaser.
* Generate versioned release archives for:

  * Linux (`amd64`, `arm64`)
  * macOS (`amd64`, `arm64`)
  * Windows (`amd64`)
* Generate SHA256 checksums for all release artifacts.
* Generate Debian (`.deb`) packages for Linux distributions.
* Generate RPM (`.rpm`) packages for RedHat, Fedora and openSUSE based distributions.
* Automatically publish GitHub releases and prereleases.
* Automatically update Homebrew tap formulas.
* Automatically update Scoop bucket manifests.
* Include `README.md` and `LICENSE` in release archives and packages.

### Supported Distribution Channels

* GitHub Releases
* Homebrew
* Scoop
* Debian packages (`.deb`)
* RPM packages (`.rpm`)

### Motivation

The previous release pipeline relied on custom shell scripts and manual package manager updates. Moving to GoReleaser reduces maintenance overhead, standardizes release artifacts, and enables fully automated package distribution from a single tagged release.
